### PR TITLE
comparison of alternative acf calculations

### DIFF
--- a/fhd_test/single_phase/.gitignore
+++ b/fhd_test/single_phase/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints/

--- a/fhd_test/single_phase/acf.ipynb
+++ b/fhd_test/single_phase/acf.ipynb
@@ -308,9 +308,9 @@
     "    data = np.roll(data,-1,axis=0)\n",
     "    data[-1] = v[t] if t<nsteps else 0\n",
     "    for idx in it.product(*map(range,v.shape[1:])):\n",
-    "        s = data if idx==() else data[:,idx]\n",
-    "        acf += scipy.signal.correlate(s,s)[len(s)-1:]\n",
-    "ac = acf/np.arange(ncorr,0,-1)"
+    "        s = data if not idx else data.T[idx[::-1]]\n",
+    "        acf.T[idx[::-1]] += scipy.signal.correlate(s,s)[len(s)-1:]\n",
+    "ac = (acf.T/np.arange(ncorr,0,-1)).T"
    ]
   },
   {

--- a/fhd_test/single_phase/acf.ipynb
+++ b/fhd_test/single_phase/acf.ipynb
@@ -1,0 +1,380 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, sys, time\n",
+    "import espressomd, espressomd.lb\n",
+    "import numpy as np\n",
+    "#from numpy.fft import fftn,fftfreq\n",
+    "import matplotlib.pyplot as plt\n",
+    "import itertools as it\n",
+    "import scipy.signal\n",
+    "import statsmodels.tsa.stattools as stattools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'agrid': 1.0, 'dens': 1.0, 'ext_force_density': array([0., 0., 0.]), 'visc': 0.08333333333333333, 'bulk_visc': -1.0, 'tau': 1.0, 'seed': 134, 'kT': 1.1111111111111111e-07}\n"
+     ]
+    }
+   ],
+   "source": [
+    "### Parameters ###\n",
+    "dim = 3\n",
+    "dx = 1 # agrid\n",
+    "dt = 1 # timestep\n",
+    "rho = 1 # density\n",
+    "tau = 0.75\n",
+    "nu = 1/3*(tau-0.5) # viscosity\n",
+    "L = 64 # side length\n",
+    "kT = 1e-6/9 #test['T'] #2.464*10**(-7)\n",
+    "################\n",
+    "\n",
+    "### Setup ###\n",
+    "system = espressomd.System(box_l=[L]*3)\n",
+    "system.time_step = 1\n",
+    "system.cell_system.skin = 0.0\n",
+    "\n",
+    "lbfluid = espressomd.lb.LBFluid(agrid = dx, tau = dt, dens = rho, visc = nu, kT = kT, seed=134)\n",
+    "system.actors.add(lbfluid)\n",
+    "print(lbfluid.get_params())\n",
+    "uid = np.random.randint(0, 1001)\n",
+    "###############"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# rolling autocorrelation as implemented in LBMeX (adopted from DSMCgran)\n",
+    "def update_autocorrelation(acf, data, x):\n",
+    "    data = np.roll(data,1,axis=0)\n",
+    "    data[0] = x\n",
+    "    acf += x*data\n",
+    "    return acf, data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "12:35:33 : Timestep  15\n",
+      "15 Timesteps run in 69.343s, average of 4.623 s/timesteps\n"
+     ]
+    }
+   ],
+   "source": [
+    "nsteps = 15\n",
+    "ncorr = 5\n",
+    "\n",
+    "Pdata = np.zeros((ncorr,L,L,L,3,3))\n",
+    "Pacf = np.zeros((ncorr,L,L,L,3,3))\n",
+    "allPeq = []\n",
+    "allPneq = []\n",
+    "\n",
+    "### Time Loop ###\n",
+    "start = time.time()\n",
+    "for i in range(nsteps):\n",
+    "    system.integrator.run(steps = 1)\n",
+    "\n",
+    "    lbf = lbfluid[:, :, :]\n",
+    "    Peq = lbf.pressure_tensor\n",
+    "    Pneq = lbf.pressure_tensor_neq\n",
+    "    allPeq.append(Peq)\n",
+    "    allPneq.append(Pneq)\n",
+    "    \n",
+    "    P = Peq + Pneq\n",
+    "    Pacf, Pdata = update_autocorrelation(Pacf, Pdata, P)\n",
+    "    \n",
+    "    current_time = time.strftime(\"%H:%M:%S\", time.localtime())\n",
+    "    print(current_time, ': Timestep ', i+1, end='\\r')\n",
+    "print()\n",
+    "end = time.time()\n",
+    "print('{0} Timesteps run in {1:.3f}s, average of {2:.3f} s/timesteps'.format(nsteps, end - start, (end - start)/nsteps))\n",
+    "#################"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAEYCAYAAABY7FHWAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAA6b0lEQVR4nO3deXxU5fn//9c1k0kChJ0gS8KOrAKyq2wKgluF1tZ9w622tr/2V/uptbYf7artp7WtS1vFvVXU4oILiBuKiOyEHQRZAwHCnkCWmcn1/eMcYhISMgkzOcnM9Xw88mBmzplzv+cmmWvOMvctqooxxhhzgs/rAMYYY+oXKwzGGGPKscJgjDGmHCsMxhhjyrHCYIwxphwrDMYYY8qxwmBMPSQin4jIbbV8bicRyRcRfwxynScim9ztT4n29k/R7mgR2VhX7SU6KwxxSES2iUiB+8e7V0SeFZE0r3N5TURuFpH5XueINvf/e8KJ+6q6Q1XTVDUcg+Z+Azzmbv/NGGwfABFREelx4r6qfqaqvWLVninPCkP8+oaqpgGDgWHALyuuICJJdZ6qHmaItYqf3Bv4a+4MrPU6hIktKwxxTlV3AbOB/lD6SewuEdkEbHIfu0xEskTksIgsEJEBJ54vIveIyC4RyRORjSIy3n18uIgsFZGj7l7Jw+7j40Qku2yGsp9oReQBEZkhIv8RkaPAzSLSXESeFpEct63fVXUYxG33Czdrjog8JiLJ7rIu7utLKrP+JyJym4j0Af4FnOPuSR12lzcXkRdEJFdEtovIL0XEV+b5t4vIevf1rxORwe7jfdxtHxaRtSJyeZnnPCci/xSRWSJyDDjf7YN7RGQVcExEkkRkpNvfh0VkpYiMq+I1dxeRj0XkgIjsF5EXRaSFu+zfQCfgbfd1/axiP4hIBxF5S0QOishmEbm9zLYfEJFX3T7Ic1/L0CpyfAV0K9NWSsW9FXd7/6nw/3GTiOxws99XZl2/iPxCRL5y214mIpkiMs9dZaXbzlUVf68i6P/HReRdd7uLRKR7Za/JVEFV7SfOfoBtwAT3dibOJ7zfuvcV+ABoBTTC2aPYB4wA/MBN7vNTgF7ATqCD+9wuQHf39hfADe7tNGCke3sckH2KPA8AQWAKzgeTRsCbwBNAE6AtsBj4bhWvbQgwEkhy86wHflwmnwJJZdb/BLjNvX0zML/C9l4AZgJN3ed/CdzqLvsOsAtnj0uAHjifmAPAZuAXQDJwAZAH9HKf9xxwBDjPfY2pbh9kuf8fjYCOwAHgEnedC9376ZXk7uEuTwHSgXnA3yrr38r6AfgU+IebYxCQC4wv8/9R6ObwAw8CCyP53ari/gPAfyrkmOa+5oFAEdDHXf4/wGqc3zNxl7cu83vao8x2x+H+XkXY/weB4Ti/Jy8CL3v9d9mQfuJmj0FEnhGRfSKyJgrbOl+cT9AnfgqlDk+0Rcmb7qfi+ThvDH8os+xBVT2oqgXA7cATqrpIVcOq+jzOH+9IIIzzZtRXRAKquk1Vv3K3EQR6iEgbVc1X1YU1yPaFqr6pqiVAM+BinDf3Y6q6D/grcHVlT1TVZaq6UFVDqroNp6CMrUHbpdy9kquAe1U1z93eX4Ab3FVuA/6kqkvUsVlVt+P0TRrwkKoWq+rHwDvANWU2P1NVP1fVElUtdB97RFV3uv1+PTBLVWe563wALMV5g674mjer6geqWqSqucDDkb5mEckERgH3qGqhqmYBT5V5jeAUy1nqnJP4N84bdDT9WlULVHUlsLLM9m8DfqmqG93+XamqByLYXiT9/7qqLlbVEE5hGBS1V5MA4qYw4HxKuCgaG1LVuao6SFUH4XwaOQ68H41t16EpqtpCVTur6vfdN6MTdpa53Rm4290lP+wWk0ycvYTNwI9xPgXuE5GXRaSD+7xbgTOBDSKyREQuq0G2iu0HgJwy7T+Bs+dwEhE5U0TeEZE94hyK+gPQpgZtl9UG5xPn9jKPbcf5NA9OP3xV8UlAB2CnW9gqex6Uf42VPdYZ+E6Ffh8FtK/4JBFp6/b9Lvc1/4fIX3MH4KCq5p0i654yt48DqRLd8yAVt3/iQoiq+rc6kfR/VW2aCMRNYVDVeTi7j6XcY7PvuccuPxOR3rXY9LeB2ap6PCpB64eyQ+ruBH7vFpETP41VdTqAqr6kqqNw3sgU+KP7+CZVvQbnDfyPwAwRaQIcAxqf2Lj7qTy9mvaLgDZl2m+mqv2qyP5PYAPQU1Wb4RxOEHfZMfffxmXWb1dFuwD7cfZ8Opd5rBPO4aMT2So7Nr0byJQy5yIqPK+ytio+thP4d4V+b6KqD1XyvAfd5w5wX/P1fP2aq2qrbNZWItL0FFlPR7n/b8r3d3Wq6t/qRNL/5jTETWGowpPAD1V1CPBTnOOsNXU1MD2qqeqXacCdIjJCHE1E5FIRaSoivUTkAhFJwTkOXYBzeAkRuV5E0t1PbYfdbYVxjtGnutsI4FwNlVJV46qag7M39hcRaSYiPregV3WopClwFMh3C/33ymwrF+fN4Xr3xOYtlH/j2QtkiHuy2j108irwe/f1dgZ+gvOJHJxDLj8VkSFu3/Rw11mE84b4MxEJiHPS+BvAy6fo54r+A3xDRCa5WVPdE6wZVbzmfOCwiHTEOTZf1l6ck8InUdWdwALgQbeNATh7ey/WIOupZAFXu/0wFOeDVKSeAn4rIj3d/h0gIq3dZVW+JqLT/+YU4rYwiHPd/rnAf0UkC+fwRHt32bdEZE0lP3MqbKM9cBYwhzilqktxzjM8BhzCOal3s7s4BXgI55P1Hpy9g1+4yy4C1opIPvB34Gr3GPYR4Ps4f/S7cP6Ay12lVIkbcQ7prHMzzKCSQyqunwLX4pxsnAa8UmH57ThvnAeAfjhviid8jHMifo+I7Hcf+6GbcQvO+ZiXgGfcvvkv8Hv3sTyck+StVLUYuBzn3Mh+nA8cN6rqhmpeZyn3DXsyTn/m4nx6/h8q/5v8Nc5FAkeAd4HXKyx/EPile0jqp5U8/xqcE8G7gTeA+91zGtHwK5zie8jN+VINnvswTmF+H6fYP41zkhqcw5fPu6/pyrJPikb/m1MT1fiZqEdEugDvqGp/EWkGbFTVqt5gItnej4B+qnpHtDIaY0x9F7d7DKp6FNgqIt8BcHdVa3q1xTXE92EkY4w5SdwUBhGZjnNtfS8RyRaRW4HrgFtFZCXOIYTJNdheF5yrJj6NQVxjjKm34upQkjHGmNMXN3sMxhhjoqPOBvNyv4H5As51ziXAk6r69wrrjMMZnmCr+9Drqvqb6rbdpk0b7dKlSzTjGmNMXFu2bNl+Va34HSOgDgsDEALuVtXl7pdtlonIB6q6rsJ6n6lqTb5FS5cuXVi6dGnUghpjTLwTke1VLauzQ0mqmqOqy93beTiDn3U89bOMMcbUNU/OMbhX/JyN8w3Gis4RZwji2SJS1bAIiMgd4gz7vDQ3NzdWUY0xJuHUeWFwv5H8Gs5omkcrLF4OdFbVgcCjON80rZSqPqmqQ1V1aHp6pYfJjDHG1EKdziTljp3zGvCiqlb8Wj9lC4WqzhKRf4gzrPP+iusaY+qvYDBIdnY2hYWF1a9sYio1NZWMjAwCgUDEz6nLq5IEZyyU9ar6cBXrtAP2qqqKyHCcPZpIxmc3xtQj2dnZNG3alC5duuD86RsvqCoHDhwgOzubrl27Rvy8utxjOA9ncpDV7qB24Awg1glAVf+FMzLj90QkhDOS59Vq38AzpsEpLCy0olAPiAitW7empudh66wwqOp8yo8hX9k6j+GM8lk3di6GbZ9Bl9GQObzOmjUmEVhRqB9q8/+QuN983jafOS9/k78sf4QVL33TKRLGGGMStzC8vWQ6P01vyXPNm3J72xZ8sKQmw8gbY0z8StjC8GHYPUMvQlCEd4q9zWOMMfVFwhaGc/tegajfvSec2/cKT/MYY2LjggsuIBQK8cQTT9CuXTsGDRpEt27deO655yLeRkFBAWPHjiUcDgPOVVevvOJMHlhcXMyYMWMIhUKl69e2rYrtvPfee/Tq1YsePXrw0ENfTwdesc1Dhw7xzW9+M+LXU52ELQxXDRjNzwc/SpOw0LW4hKv6n+d1JGMS2rLth3h87maWbT8UtW2uXbuW1q1bk5SUxKpVq3jggQfIyspixowZ3H333RFv55lnnuFb3/oWfr/zYfKjjz5i+fLlACQnJzN+/PjSQgHUuq2y7YTDYe666y5mz57NunXrmD59OuvWrau0zZYtW3Lw4EEOHIjO1f11+gW3+ubagWNYvmooc/xLWLlsOgOHXed1JGPizq/fXsu63RUHOSgvrzDIhj15lCj4BHq3a0rT1Kq/kNW3QzPu/0aVI+aUmjlzJlOmTAFg9erVXHmlM310RkZG6afySLz44ou89JJzHnL+/Pn85Cc/oUWLFsyZM4c33niDKVOmcO+993LdddedVltl21m8eDE9evSgW7duAFx99dXMnDmTvn37ApzU5qWXXsrbb7/NzTffHPHrqkrC7jGccP2Ye/Cp8lrWNK+jGJOwjhaGKHG/sVSizv1omDVrFpdeeingvFn37t0bVeWRRx7hsssiG8S5uLiYLVu2cGJo/1GjRjFs2DBmzpxJVlYWXbt2pX///ixZsqT0ObVpq2I7u3btIjMzs3R5RkYGu3btKr1fsc3Jkyfz5ptvRvSaqpPQewwAgzr3ondxcz7z76M4L5fkpjbukjHRFMkn+2XbD3HdUwsJhkoIJPn4+9VnM6Rzy9Nqt6CggOLiYlq0aMHOnTvJz89n0qRJBAIBhg8fzuOPPx7Rdvbv30+LFi3KPbZx40Z69epVet/v95OcnExeXh6HDx+uVVsV26nsu71lv5NQts2mTZvSq1cvNm7cGNFrqk7C7zEAnNvxCvYn+Xnjwz94HcWYhDSkc0tevG0kP5nYixdvG3naRQGgUaNGiAj5+fmsWrWK8ePHk5WVxZIlS3j88cdp3rw5ubm5TJ06lezsbG655RaCwSDPPvsss2fPRlW55ZZbEJFyYz4dOHCA5s2bnzT2UFFREampqRG3NW3atFO2k5GRwc6dO0vvZ2dn06FDh0rbBNi+fXuNhr04lYTfYwC4dcL3+e+Lz/Lx3o+5yuswxiSoIZ1bRqUglDVp0iTee+89Nm/ezMCBA09anp6eTqdOnbj77rt5+umnCQQCjBkzhmeeeYZdu3Zx1VVX0b59e8LhMIWFhaSmprJ169aT3qAPHDhAeno6gUCA1atXR9TW3r17T9nOsGHD2LRpE1u3bqVjx468/PLLpecfKrYJzvmUyZMnR6XfbI8BSEtJZQA9WZwaZvvGj72OY4yJkhPH3VevXs2AAQNOWp6fn8+WLVtISkoiLS0NgO7du7NixQqysrKYNGkSABMnTmT+/PkA9O7dm/3799O/f38WLFgAwNy5c7nkkksAIm6runaSkpJ47LHHmDRpEn369OHKK6+kX7+vD8uVbRPg7bff5vLLLz/tPgOc41gN/WfIkCF6uj5Y9Zn2f66//vGZS097W8YkunXr1nkdodSAAQM0GAye9HgwGNSpU6fqtm3b9E9/+pPOnTu3dNk3vvEN3bt3b+n95cuX6/XXX19lG9/85jd1w4YNVS6vqq2atlNVmwcPHtTRo0dXuW5l/x/AUq3iPdXzN/Vo/ESjMKiqfuOJIXrpk320pOh4VLZnTKKqT4WhJg4fPqx33XWXzpgx46RlTz/9tIZCoZMeLyoq0ueffz7m7ZxOmzUtDKJxMKr10KFDdenSpae9nd/O+DmvHnuXv7S7lomT7o1CMmMS0/r16+nTp4/XMYyrsv8PEVmmqkMrW9/OMZRx24SfkVqizN520uRyxhiTMKwwlNG+RSv6hzqwIPk4h3LWeR3HGGM8YYWhgol9b+e4z8f0j37vdRRjjPGEFYYKrhx5Be2CPj47tgJKIh9LxRhj4oUVhgr8fh+DU4ezJtXP0kX/9jqOMcbUOSsMlbjh/Hvxq/LG6me8jmKMMXXOCkMl+nfsRp/iFsxP2k/h0b1exzHGmDplhaEKozpdyUG/n9fe/53XUYwxpk5ZYajCzRd8l5YhmLv/U4iDLwEak6iiPbVnvE/rCVYYqtQkOYWBvt4sTS3hqw0feh3HGFMLsZjaM96n9QQrDKf07ZF3Exbh1S/+6nUUY+LfzsXw2V+cf6Ok4tSeJ4aFqM3UnpMnTy6d1nPGjBkMGjSIrVu3MmXKFF588cXSdWvbzok2oPy0nsnJyaXTep5Qsc0T03pGi83HcApj+4yk+2epzJdtlBQdw5fSxOtIxjQ8s38Oe1afep2io7B3DWgJiA/O6A8pzapev91ZcPFDVS93zZo1i3feeQeIztSeXbp0YdiwYfz5z3+mf//+AITD4TqZ1nPRokWl9yub1vOee+6JynzPYHsM1RrRZhI7kv3M/vhhr6MYE78KjzhFAZx/C4+c9iarmtpz+PDhHDp0qNZTe55qWs/atnM603oCUZ3WE2yPoVq3XvhT3pjxJnO2z+RSfuV1HGMangg+2bNzMTx/OYSLwZ8MVzwFmcNPq9nKpvZ87733yq3z7LPP0q5dOy666CJuvfVWHn/8cfbt28e0adPYunUrIsKjjz5aOuVmpNN6VtfO/fffX2Ub4O20nmB7DNVq27QFZ4UzWJhSQO6uVV7HMSY+ZQ6Hm96CC+5z/j3NonDCiak9q5puc8yYMcyfP5+nn36aq666ikaNGtG5c2duvfVW/H4/TzzxBC1btiydcrO203pWbOdUbQDlpvUsLi7m5ZdfLjc7Wyyn9QQrDBG5uP93KfD5ePnjB72OYkz8yhwOo++OWlGA6qf2rGx6zW3btvHAAw/wz3/+kyZNnPOKJ6bcrO20nhXbOVUb4PG0nmAzuEUiHA7rxCcH6nee6KMaPvXMSsaY+jWDW1VTe55QcXrNPn366I9//GO977779MCBA6p66ik3q5vWs7J2atrGqdqsblpP1ZrP4GbnGCLg8/kY0mQkbwc/54sFz3LOqNu8jmSMidDKlSsrffzIkSPcd9993HTTTbRt27b08RPfFyjr7LPP5vzzzyccDuP3+0sfLy4uZsqUKeVORkfSTk3aqKhimy1btmTevHlVrl8bdTa1p4hkAi8A7YAS4ElV/XuFdQT4O3AJcBy4WVWXV7ftaE3teSpf5mzjqjmXcVFxSx6847OYtmVMQ2dTe9Yv9XlqzxBwt6r2AUYCd4lI3wrrXAz0dH/uAP5Zh/lO6cz2Xehb3Ir5SQcoOLLb6zjGGBMzdVYYVDXnxKd/Vc0D1gMdK6w2GXjBPQS2EGghIu3rKmN1xna9hsN+P6++b7O7GWPilydXJYlIF+BsYFGFRR2BnWXuZ3Ny8TixjTtEZKmILM3NzY1JzopuHHcbrULwyYF5NrCeMSZu1XlhEJE04DXgx6p6tOLiSp5S6Tuwqj6pqkNVdWh6enq0Y1YqNRBgkL8fy1OVDWtn10mbxhhT1+q0MIhIAKcovKiqr1eySjaQWeZ+BlCvDuhfde7/UCLCjEWPeB3FGGNios4Kg3vF0dPAelWtauCht4AbxTESOKKqOXWVMRLnnjmEM4saMV93EC7K8zqOMcZEXV3uMZwH3ABcICJZ7s8lInKniNzprjML2AJsBqYB36/DfBEb0fYSdgX8vP3hn72OYowxUVdnX3BT1flUfg6h7DoK3FU3iWrv1gl38/qrM/hw5ztM4ddexzHGmKiysZJqoXVaUwaUdGJhSiE5O6r9/p0xxjQoVhhq6dJBd1Hk8/HyJxEMKWyM8YzN+VxzVhhq6RuDLyazOIn5hWsgHKr+CcaYU8ral8VTq58ia19W1LZpcz7Xjg2iV0s+n4+haefyRvE8Pvt8GqPHfM/rSMbUS39c/Ec2HNxwynXyi/PZeGgjiiIIvVr2Ii05rcr1e7fqzT3D76m27YpzPl955ZVA7eZ8fumll0rnfG7RogVz5szhjTfeYMqUKdx7771cd911p9XOiTag/JzPQOmcz337OqMIVWzzxJzPNrVnPXDzhHsJqPL2+v94HcWYBi0vmIe632VVlLxgdC4FnzVrFpdeeikQnTmfR40axbBhw5g5cyZZWVl07dr1pPmXYzXn865du0rvVzbn85tvvhnR64mE7TGchm7pGfQPtmZBYD/5B3eS1iqz+icZk2Ai+WSftS+L29+/nWBJkIAvwEOjH2JQ20Gn1W5Vcz4HAgGGDx8ekzmfDx8+XKt2TmfO56ZNm0Z9zmfbYzhN47pfzxG/j1fe/53XUYxpsAa1HcS0idP4wdk/YNrEaaddFKDyOZ+zsrJYsmQJjz/+OM2bN2f79u388pe/5LrrruP6668nNzeXqVOnkp2dzS233EIwGKRRo0Y1nvO5pu0EAgGb8zme3DD2FtqEYN6RBTawnjGnYVDbQdx21m1RKQonVDfnc8W5l9PT0+nUqRN33303jzzyCIFAICpzPlfXTnp6us35HE8Cfj9nJ53FihRlzaq3vI5jjCmjujmfK869nJ+fz5YtW0hKSiIt7euT36c753Mk7diczw1szufqLPlqpZ71bD+9f9qFnuYwpr5oKHM+l517ee/evTp16lTdtm2b/ulPf9K5c+eWrne6cz5H0k59mvPZ8zf1aPx4XRhUVb/9xHCdMK2PBo8f8TqKMZ6rT4UhWp5++mkNhULlHisqKtLnn38+pm1UVJs2a1oY7FBSlJzb7jL2BPy8+eEfvY5ijImBW265Bb/fX+6x5ORkbrzxxpi2UVG026yMFYYoueXCn5AWVj7eZRP4GGMaNisMUdK8URMGaVcWpRSza9uS6p9gjDH1lBWGKJo85IcU+4Tpn9rAesaoXb5dL9Tm/8EKQxRdNGginYqT+LxovQ2sZxJaamoqBw4csOLgMVXlwIEDpV+Ei5QNiRFlw5uNYUbhx3w075+MP/+HXscxxhMZGRlkZ2eTm5vrdZSEl5qaSkZGRo2eY4Uhym6ZcC9vvfURs758yQqDSViBQCCqQzSYumWHkqIss3U7zgqlsyBwlMP7t3odxxhjaswKQwyM73kT+X4fr3zwe6+jGGNMjVlhiIFrRt9AelCYf3ShDaxnjGlwrDDEQJLfz9DkgWSlCitWvO51HGOMqRErDDFy3dh7EVXeWPZPr6MYY0yNWGGIkYGd+9KnOI3PfbspPn7Y6zjGGBMxKwwxNKrjFPYl+Xn9ffsmtDGm4bDCEENTx/+IZmFl7p45XkcxxpiIWWGIobTURgyiG4tTg2zb/IXXcYwxJiJWGGLsm8N+TEiEVz77k9dRjDEmIlYYYmzCWRfQtTjA56GNlASLvI5jjDHVssJQB0a0GMfWZD/vf/oPr6MYY0y1IioMItJSRG4UkTdEZK2IvCMit4vIGbEOGA+mTryXlBJlzleveB3FGGOqVW1hEJHXgdeBtsA9qtoP+D6QCvxbRD6JacI40KF5OgNCZ7AwOY9D+77yOo4xxpxSJHsMt6jq+ar6Z1X9EkBVd6jqo6o6EZgSaWMi8oyI7BORNVUsHyciR0Qky/3530i3Xd9N6jOVfJ+Plz78nddRjDHmlKotDKp6uOx9EWkiIv6qllfjOeCiatb5TFUHuT+/qcG267XvnHstZwSFz/OW2MB6xph6LZJDST4RuVZE3hWRfcAGIMc91/B/ItIz0sZUdR5w8DTyNlg+n4+hqYNZnSosWWLnGowx9Vckh5LmAt2Be4F2qpqpqm2B0cBC4CERuT6Kmc4RkZUiMltE+lW1kojcISJLRWRpQ5k+8Mbz78Wnypsrn/Q6ijHGVCmSqT0nqGqw4oOqehB4DXhNRAJRyrMc6Kyq+SJyCfAmUOkeiao+CTwJMHTo0AZxbKZvx170LW7GAv8eCvP3k5rWxutIxhhzkkjOMQRFpLeI3CMij4jI393bfcquE40wqnpUVfPd27OAgIjE1bvnmMxvsT/Jz3/nPOh1FGOMqVQk5xjuAV4GBFgMLHFvTxeRn0czjIi0ExFxbw938x2IZhteu2n8D2geVublfuR1FGOMqVQkh5JuBfpV3CsQkYeBtUDEY0qLyHRgHNBGRLKB+4EAgKr+C/g28D0RCQEFwNWq8XUJT+PkVAZLTz5L3cSmL+fR88wxXkcyxphyIikMJUAHYHuFx9u7yyKmqtdUs/wx4LGabLMh+s6InzB3yff57/y/8AsrDMaYeiaSwvBj4CMR2QTsdB/rBPQAfhCjXHFtdN/RdP88mc/ZREmwEF8g1etIxhhTKpKTz+8BZwK/BuYA7wMPAL3cZaYWRrYaz45kP7M+fsTrKMYYU04kJ59FVUtUdaGqvqaqM9zb4bLrxDZm/LnlwntILVHe3/qa11GMMaaciL7gJiI/FJFOZR8UkWQRuUBEngduik28+NW2WWsGhtuzKCWf3D0bvY5jjDGlIikMFwFhnMtTd4vIOhHZAmwCrgH+qqrPxTBj3Lqk/+0c9/mY/uHvvY5ijDGlIjnHUKiq/1DV84DOwHhgsKp2VtXbVTUr1iHj1ZTh36Z90MeCY8tsYD1jTL1RoxncVDWoqjk1HFHVVMHn8zG80VDWpvr4YuF/vI5jjDFALab2FJFZIvKQO4vb0+43lE0t3XjBL/CrMnP1015HMcYYoHZzPn+Jc6nqZcBtwI3RjZRYzmzfnf7B5nyRtI9jRxvGKLHGmPhWm8KwA+cK1TuBs3Gm/DSnYVzn73DQ72fG+3YS2hjjvRoXBlV9GHgCWAVcAIRF5MVoB0skN5z/fVqG4NP9c72OYowxtdpjALgQ+C2QD4RV9broRUo8KYFkhvh7sTw1zMb1H3sdxxiT4GpbGBoDdwD7gV3Ri5O4rj73p4RFeHXBw15HMcYkuNoWhqNAJvAGztwM5jSNOHMkPYtSWKBbCBcVeB3HGJPAalsY7gcGA88BG6KWJsGdm34h2QE/b338V6+jGGMSWCSD6N0kIvtF5KCIvCAiTVW1QFUfVtUbVPWZugiaCG6d+HMalygfbX/D6yjGmAQWyR7Dr3BONvfGmaznDzFNlMBaNmnOoHBHFqUcJ2fXOq/jGGMSVCSF4aiqrlDVfar6K8C+6RxDlw34LoU+Hy9/bPXXGOONSApDexG5Q0RGi0g67hzNJjYuHTqFjkEfCwpWQEmNZk41xpioiKQw3A8MAH4HbAT6u+MlPSgip5zD2dScz+djZJMRbEjx8emCF7yOY4xJQJEMu/2kqv5AVceqaiugG/AYcBi4NMb5EtJN439BkirvrrXz+saYupdUi+ccAuao6qxohzGOrm270D/Yki8C+8k7spemzc/wOpIxJoFEcrmqT0SuFZF3RWQfzuGkHBFZKyL/JyI9Yx8z8YzvejWH/X5emfM7r6MYYxJMRHM+A92Be4F2qpqhqm2B0cBC4CERuT6GGRPSdWPvoHUI5h+c53UUY0yCiaQwTFDV3wJHVLX0MhlVPaiqr6nqFcArMUuYoAKBAEOT+rAiNczqVXO8jmOMSSCRnHwOujdP+jquiIyssI6JomtH/YwSEV5b/HevoxhjEkgk5xiuFJGHgKYi0kdE/GUWPxm7aGZw96H0KkrlC7YRLDrudRxjTIKI5FDS58A6oCXwMLBJRJaLyDuADQMaY6POuJjdAT9vfvBnr6MYYxJEJIeSdqnqC8BkVb1YVbsBE3C++HZBrAMmuqkT/4cmYeXj7Le8jmKMSRCRHEoSAFX9/MRj7onnZap6rOw6JvqaN2rK2ZrJkpQCsrev9DqOMSYBRHS5qoj8UEQ6lX1QRJJF5AIReR64KTbxDMCUs79Pkc/H9E8e8jqKMSYBRFIYLgLCwHQR2S0i60RkC7AJuAb4q6o+F8OMCW/i2ZfRqdjPF0Wr0JKw13GMMXEuknMMhar6D1U9D+gMjAcGq2pnVb1dVbMibUxEnhGRfSKyporlIiKPiMhmEVklIoMj3XY8ExFGND2HTSk+Pppn4ycZY2KrRlN7qmpQVXNU9XAt23sOZw+kKhcDPd2fO4B/1rKduDP1wvsIqDJ7o424aoyJrRrP+ewOuf2QiLwjIk+LSMQT96jqPODgKVaZDLygjoVACxFpX9OM8SizdQYDgq1YFDjIkYM5XscxxsSxGhcG4Eugl6peBtwG3BjFPB2BnWXuZ7uPncSdPGipiCzNzc2NYoT668Ke13PE72P6+7/xOooxJo7VpjDswDkdcCdwNtA2inkqu+xVK1vRnSdiqKoOTU9Pj2KE+uvqMbfSJgQLDn9e/crGGFNLNS4MqvowcBWwGucLbmEReTFKebKBzDL3M4DdUdp2g+f3+RkW6E9Wagkrst71Oo4xJk7VZo8B4BxV/VxV/6yq16jqdVHK8xZwo3t10kicEV3tgHoZN4z9OQCvL3nU4yTGmHhVmxncAC4XkV8BrwKjVTWi+RhEZDowDmgjItk4w2oEAFT1X8As4BJgM3AcmFrLfHHrrM4D6RNszELZQXFhPsmpaV5HMsbEmdoWhsY4l5OeDeyK9Emqek01yxW4q5aZEsbo9pfxxIH/8tqc/+Oayb/2Oo4xJs7U9lDSUZxzAW9Q+QljE0M3X3g3aWHlk5x3vI5ijIlDtS0M9wODcb6wtiFqaUxE0lKaMITOLE0pYuvW5V7HMcbEmUhGV71JRPaLyEEReUFEmqpqgao+rKo3qKqN0eCBK4b8fxT7hFc+fdDrKMaYOBPJHsOvgAuB3sB24A8xTWQicv7ASXQpTmJh8To0HPI6jjEmjkRSGI6q6gpV3aeqvwIiHgLDxNY5zUfxVYqPOZ/YDKvGmOiJpDC0d4efGC0i6biXlxrv3XLhfSSXKHM2R+v7hcYYE9nlqg8AA4DrgLOANBGZBawEVqnq9NjFM6fSrmU7BoXasDCQy/79O2nTJrP6JxljTDUi2WOYpqo/UNWxqtoK6AY8BhwGLrFpPb01qfeN5Pt9vPL+77yOYoyJE5EUhg9E5BURuUZEmqlqNvAJzreTAex6SQ9dcd5NtA3CgrwFoJWON2iMMTUSyQxu44FfA12Ad0VkIfARzmGlv6rq2TFNaE7J7/MzImUAq1Jh8fKZXscxxsSBiL7gpqrrVPVBVR0NjFPVc1T1AVW1vYV64IZxv0BUeXP5P7yOYoyJA7UZdrswFkFM7fXJ7Ee/YBMW+bIpOHbU6zjGmAautkNimHpmXMfJ7Evy898P/uh1FGNMA2eFIU7cOP7/p1lY+WzPbK+jGGMaOCsMcaJRSiOGSleWphazadMir+MYYxowKwxx5DvDf0RIhFfn/8nrKMaYBswKQxwZ1W8C3YqTWBTaQDgY9DqOMaaBssIQZ85rNZatyT5mfWKXrhpjascKQ5y5ZeJ9pJQoH3z1itdRjDENlBWGONOmaTpnh9uyOOUI+/Zt9TqOMaYBssIQhy7pO5VjPh/TP7CB9YwxNWeFIQ5NHnkd7YPCwvzFNrCeMabGrDDEIZ/Px4hGg1iTCvMXz/A6jjGmgbHCEKduPP8+fKq8s/IJr6MYYxoYKwxxqmeHXvQPprHIv5v8/ENexzHGNCBWGOLYBZ2+xf4kP6/OedDrKMaYBsQKQxy7/oIf0SKszM/90OsoxpgGxApDHEsJpDDM150VqcWs2/i513GMMQ2EFYY4d9U5PyUkwozP/+x1FGNMA2GFIc6N6DWansUBFoW/JBQs9jqOMaYBsMKQAEa1voAdyT7e+uhRr6MYYxqAOi0MInKRiGwUkc0i8vNKlo8TkSMikuX+/G9d5otXN0+8l9QS5eNt9mU3Y0z1kuqqIRHxA48DFwLZwBIReUtV11VY9TNVvayuciWCVmmtGRI+gyUpe9i9ezMdOvTwOpIxph6ryz2G4cBmVd2iqsXAy8DkOmw/oX3jrNs57vMx/SMbWM8Yc2p1WRg6AjvL3M92H6voHBFZKSKzRaRf3USLf5cMv4oOQWHx8aVoSYnXcYwx9VhdFgap5LGKQ38uBzqr6kDgUeDNKjcmcoeILBWRpbm5udFLGadEhHMbD2FdqvDpQpvExxhTtbosDNlAZpn7GcDusiuo6lFVzXdvzwICItKmso2p6pOqOlRVh6anp8cqc1y5afx9+FV5d800r6MYY+qxuiwMS4CeItJVRJKBq4G3yq4gIu1ERNzbw918B+owY1zrckYPBgSbsci/l7yjB72OY4ypp+qsMKhqCPgBMAdYD7yqqmtF5E4RudNd7dvAGhFZCTwCXK1qM81E04Qu3+ZQko/pc37vdRRjTD0l8fC+O3ToUF26dKnXMRqEYKiYCc8PpmswiefuzPI6jjHGIyKyTFWHVrbMvvmcYAJJyQxPOpOs1BCr1n7qdRxjTD1khSEBXXve/xAW4bWFf/E6ijGmHrLCkIDO7nEOvYqTWaybCRYXeR3HGFPPWGFIUKPTLyQ74Of1D//mdRRjTD1jhSFBTZ34cxqXKJ/seN3rKMaYesYKQ4Jq1rgFQ0raszQln+3ZG7yOY4ypR6wwJLApA79Loc/HKx/bdxqMMV+zwpDALhxyBZlBH4sLV9jAesaYUlYYEpiIcG7acDamCB9+/h+v4xhj6gkrDAnu5gm/IEmV2eue8TqKMaaesMKQ4DLadGVgsDlLArkcOrzP6zjGmHrACoNhUverOey3gfWMMQ4rDIbvjLmTNiFl4SEbO8kYY4XBAElJAUYEerMyNcSylR96HccY4zErDAaA60b/jBIR3ljyN6+jGGM8ZoXBAHBW1+H0KU5hCVsoKirwOo4xxkNWGEypce0uYnfAz4w5D3sdxRjjISsMptSNE35Gk7Ayb/dMr6MYYzxkhcGUSmvUjGF0ZFnKcbZsW+t1HGOMR6wwmHKuGPJ9inzCK5/adxqMSVRWGEw5YwdcTudiH4uLVlEStoH1TsfMT5/if5//DjM/fcrrKMbUSJLXAUz9IiKMan4OLxZ8zux5z3Lp+bd6HalBCZeEWZ2ziVfm/ZnZRQspAd7Zup6c47ncPuln+H1+ryMaUy1RVa8znLahQ4fq0qVLvY4RN3IO7OTSty9mTFFr/vZd+zZ0VfYcPcBnGz5h3Y4F7MzbwJ7wXnL8RRSf2A9XBZHS9VNKoF04lfb+dnRu2YezOo9hdO9RtGrUwpP8JrGJyDJVHVrZMttjMCdp3zqTQcGWLAnsZ//BPbRp1c7rSJ4qDBWzaMtysjZ9xJYDq9hTlE2OL49DSV9/qGqpYbqGlLOCzeiQkkmJL4l/62qCQJLCxUWtCGkhuyWP9b6vWHhkG6+smg2roHXIR3ttRofUzvRoO5hhvcYzMKMvAX/AuxdtEpoVBlOpi8+8liXb/sH0Ob/jh9c85nWcOqGqbNq3gy/WfcCmnMXsOr6FvXqAnECQkPvJP0mVrhpiYHEjOpScQecWvTmryyj69B5HUtM25bbX5dOnWLZtDkO6TmLy2NtKHy8+nMO69Z+yevt8dhzdSE54HzuTcvkodIj3c1ZCzrMklyjtwym087WlU9Mz6dvpXEb1HU+7Cm0YEwt2KMlUKhwOceFzZ9M+5OPF7670Ok7UHT5+jPnr5rJu22fsOLqevaE97E4q4GiZUwBtQ2E6Bf10kFZkNulK7/bDGNxvPM3angm+KF+3EQ6Ru3MNyzZ8yOa9y8gu2E4OR9iWrBz0fx2qVUhoX5JG+5QMurUewOBe4xnWdQjJ/uTo5jFxzw4lmRrz+5MYmdyXd/xr+WL5bM4ZfLHXkWolFC5h+daVrPjyQ7bmriCnaCd75Qh7AiWE3b2AVCmhMzC0OI2OKR3p3mYAg8+8gK7dR0BSSt0E9SeR3mUQF3UZVO7hcMFRNqz/lJVbPmXr4fXkBHPY7T/EJyVH+XD/etj/CoH5SvtggHbSisy0HvTuOIJz+k6kc+uMuslu4o7tMZgqbdixgis/voFLg5148PZZXsc5JVVlx/49LFo7h027F7Hr2Gb26gF2JRVzzP/1CeAOwTAZ4RQ6+NvSpXkvzup8LoP6TSC5SQM6RKPK4X1fsXTNB2zMWUz2sS3s1oPsCITZn/T13kWLMHQIN6Z9oANdWvZjYPexnHPmGFKT66jYmXrtVHsMVhjMKV0zbRj75ThvXb+YRqlNvI4DQH5hIYvXzmPNtk/ZeXgte0M55PiPsSfwdQFoUlJC56CPDrQks0kXercfwrA+k0hv16vclULxRENFfPnlAlZsmsuWA6vZXbyL3b58tgd8FPuc1+xXpUPQT3ta0LFxV85sN5QRfSfRo10PJE77xVTOCoOptSfffYBH97/G3c2v4OYpD9Rp26FwCeu2rifry/edw0CF29grh9kVCFPgHuMXVTJC0LGkCR2TO9CjdT+G9Dyf3j1GI0l23B0g//Belq55j3U7F7IzbxM5msvOpCD7yuxdNAsrHUOptE86g87N+9C/yyjO6TuBpo3SPExuYskKg6m1gqJjjH9xBP2KGzHtziUxaUNV2bM/l6VrP+TLXV+wK/9L9mkuOYEi9iV9fZK3WbiETqFkOvjT6dK8JwMyRzK07ySaNG0bk1zxTEvCbNu2nGUbPmJT7gp2Fe4gR/LYEVAK3aLrV6V90LmUtmNqJ7q3HcTwPhPpnTkAX7RPvps6ZyefTa01SmnCMOnE/JQdbNiSRe9ug05re8cKili5fgFrt3zCzsOr2RvcxV7/MXYG+PpwR4qSEfTRQ1txQVInerUbzIi+E8k4ox9ib0hRIT4/XbsNo2u3YeUeLzx+hGVrP2DNts/ZdmQDOSV72ek/xBI9AntXw95/0zSsZISSaedr41xKmzmSc8+6mBZNW3v0ahLTzBOXQ3cpfzl0NNTpHoOIXAT8HfADT6nqQxWWi7v8EuA4cLOqLq9uu7bHEFvzV8/ie8vv4aqSfvxy6ssRPScUCrNlxyayNnzA1n3L2FOwlX1yiOxAiINJZS+/VDJKGpOR3I4erfpxdo+xDOwxjkAgNVYvx9RC9u4NLFk7h417lrGrYCs5HGFHhUN6HULQIZxGh+QMurY5i8E9xzOw5zn4/DYMyKmoKsGwcjwYJK8gn/xjR8grOMyxgiMUFOZxvDCPguI8CovzKQoepyh4nF1H1jE3aQthIFnhV91+XOPiUC8OJYmIH/gSuBDIBpYA16jqujLrXAL8EKcwjAD+rqojqtu2FYbYu3zaIIQgr09diT/p6x1NVWVv7gHWrP+IL7MXsDtvI/tK9rEnUMiOgK/0ktCAKpmhAB19renSrDv9M0cyvPeFtGlul1Q2VKFgESvWfULWlk/YemgtOcEcdvmPkxP4eq+uSUkJmcEk2ksrMpp0p3fH4YzodzFntMn0MPmphcIlHCss4Oixg+QdO8yxgqMcKzjC8aI8CoryKCw+5vwEj1EUOk5xqJDicAHF4SKCJUWESooJajFBDRLUEGFCBAkRIkxQSghRQrEoQVGCAsWiFIuU7jHXlF+Vy6UPv7npvzV6Xn05lDQc2KyqW9xQLwOTgXVl1pkMvKBOtVooIi1EpL2q5tRhTlOJ0S3O44Xj8/jRtNF0TO4E4TB7g9ns8+exPVk5euJTYSNIDwkZtGRAcia9zhjEsF4T6NFhEEk+O3IZT5ICKQwbOIlhAyeVe3zfgWwWrnmPDbsWsfPYV+RwkEVJ+5gb3A/bFsG2R+kQLKFjuDHtk9rTuWVfBnYby+5D21ix4+Nyh0ZCxUXkHz9C/rHD5BccIf/4YfIL8ykoOkpBUT4FJz5Fh45TFCygOFxAUbiQYLiI4pJi541ag4TUeXN2fsLum7QSlBKCOG/SxQJFPigWKf2me40I4Ickn5KiSrI6n+YDKiSrEFAhBR9NCBBQP8maRJL4CUiAZF8yyZpMwJdMsi+VlKRUUpIakRpIJTXQhEbJTUhNTqNJShpNUpuycutCHj/0DkFxhlwZ0nVStfFqoi7/UjsCO8vcz8bZK6hunY7ASYVBRO4A7gDo1KlTVIOak3Vs3h2OfcqnjfOBdZAEqQHIDDdmSNIZdG/Zm8HdRjOw+1iapbbwOq7xUNvWGVw+9jYu5+tDGyXhMKs2f8HyzR/x1f7V7C7ZxS5/Pkv9W9C8rbDyXWfQQeCNret56KuHCYtQJEJJbd6kfc5PcomSrEqK+wYdUCEZIaA+kvGTpskkkUQAPwECJJcECPiSCUgyyb4Ukv3OG3RKkvMGnRpoRKPkNBqlpNE4tSlNUpqR1rgZTRs3p2njFqSmNicp0Djml0QPHjiFVp/2qHTIlWioy8JQWU9VPI4VyTrOg6pPAk+Ccyjp9KKZ6mzI+QLB+c8QVS6kG/9385v4xE4Gm+r5/H4G9RrFoF6jyj1+KO8AX6yZwyur/87y5GPOG6oq7UIBuvo7Om/SvhRSfCkkJzUi2Z9KaqAxKYHGpCY7n6QbpzSjSWoaTRo1o0mj5jRt0oJmjVvSKCUNXxwPcz557G1RLwgn1GVhyAbKHljMAHbXYh3jgSFdJjFry3pCKEkKY7pdbkXBnLaWTVtzyTnXEiw+ztotfyv9/bq51w9j9qZnqleXhWEJ0FNEugK7gKuBayus8xbwA/f8wwjgiJ1fqB9O/JHGatfVJDb7/apf6vpy1UuAv+FcrvqMqv5eRO4EUNV/uZerPgZchHO56lRVrfZyI7sqyRhjaqa+XJWEqs4CZlV47F9lbitwV11mMsYYU54dJDbGGFOOFQZjjDHlWGEwxhhTjhUGY4wx5VhhMMYYU05czMcgIrnA9lo+vQ2wP4pxosVy1YzlqhnLVTPxmKuzqqZXtiAuCsPpEJGlVV3L6yXLVTOWq2YsV80kWi47lGSMMaYcKwzGGGPKscLgjtBaD1mumrFcNWO5aiahciX8OQZjjDHl2R6DMcaYcqwwGGOMKSchCoOIXCQiG0Vks4j8vJLlIiKPuMtXicjgepJrnIgcEZEs9+d/6yjXMyKyT0TWVLHcq/6qLpdX/ZUpInNFZL2IrBWRH1WyTp33WYS56rzPRCRVRBaLyEo3168rWceL/ooklye/Y27bfhFZISLvVLIsuv2lqnH9gzP3w1dANyAZWAn0rbDOJcBsnKlFRwKL6kmuccA7HvTZGGAwsKaK5XXeXxHm8qq/2gOD3dtNgS/rye9YJLnqvM/cPkhzbweARcDIetBfkeTy5HfMbfsnwEuVtR/t/kqEPYbhwGZV3aKqxcDLwOQK60wGXlDHQqCFiLSvB7k8oarzgIOnWMWL/ooklydUNUdVl7u384D1QMcKq9V5n0WYq865fZDv3g24PxWvgvGivyLJ5QkRyQAuBZ6qYpWo9lciFIaOwM4y97M5+Y8jknW8yAVwjrtrO1tE+sU4U6S86K9IedpfItIFOBvn02ZZnvbZKXKBB33mHhbJAvYBH6hqveivCHKBN79jfwN+BpRUsTyq/ZUIhUEqeazip4BI1om2SNpcjjOeyUDgUeDNGGeKlBf9FQlP+0tE0oDXgB+r6tGKiyt5Sp30WTW5POkzVQ2r6iAgAxguIv0rrOJJf0WQq877S0QuA/ap6rJTrVbJY7Xur0QoDNlAZpn7GcDuWqxT57lU9eiJXVt1pkUNiEibGOeKhBf9VS0v+0tEAjhvvi+q6uuVrOJJn1WXy+vfMVU9DHyCM897WZ7+jlWVy6P+Og+4XES24RxyvkBE/lNhnaj2VyIUhiVATxHpKiLJwNXAWxXWeQu40T2zPxI4oqo5XucSkXYiIu7t4Tj/XwdinCsSXvRXtbzqL7fNp4H1qvpwFavVeZ9FksuLPhORdBFp4d5uBEwANlRYzYv+qjaXF/2lqveqaoaqdsF5n/hYVa+vsFpU+yup9nEbBlUNicgPgDk4VwI9o6prReROd/m/gFk4Z/U3A8eBqfUk17eB74lICCgArlb3EoRYEpHpOFdftBGRbOB+nBNxnvVXhLk86S+cT3Q3AKvd49MAvwA6lcnmRZ9FksuLPmsPPC8ifpw31ldV9R2v/yYjzOXV79hJYtlfNiSGMcaYchLhUJIxxpgasMJgjDGmHCsMxhhjyrHCYIwxphwrDMYYY8qxwmCMMaYcKwzGGGPKscJgTIyISIaIXOV1DmNqygqDMbEzHmf+CGMaFPvmszExICKjgJnAYSAP+KaqbvU0lDERssJgTIyIyHvAT1W10qlIjamv7FCSMbHTC9jodQhjasoKgzExICKtcYY+DnqdxZiassJgTGx0pR5MXmRMbVhhMCY2NuDMG7FGRM71OowxNWEnn40xxpRjewzGGGPKscJgjDGmHCsMxhhjyrHCYIwxphwrDMYYY8qxwmCMMaYcKwzGGGPK+X+al4OmpQb0zQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for i in range(3):\n",
+    "    pacf = Pacf.mean(axis=(1,2,3)).T[i,(i+1)%3]\n",
+    "    plt.plot(pacf,'.-',label=r'$\\langle P_{%c%c}(t) P_{%c%c}(0) \\rangle$'%tuple([120+i,120+(i+1)%3]*2))\n",
+    "plt.legend()\n",
+    "plt.title('Pressure autocorrelation function')\n",
+    "plt.xlabel('$t$')\n",
+    "plt.ylabel(r'$\\langle P_{\\alpha\\beta}(t) P_{\\alpha\\beta}(0) \\rangle$')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Viscosity at tau = 0.75 \b: nu = 2.3328919345191483\n"
+     ]
+    }
+   ],
+   "source": [
+    "nu = np.mean([Pacf.mean(axis=(1,2,3)).T[i,(i+1)%3].sum() for i in range(3) ])\n",
+    "nu /= kT\n",
+    "print(\"Viscosity at tau =\",tau,\"\\b: nu =\",nu)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pressure autocorrelation:\n",
+    "\\begin{equation}\n",
+    "ACF(t') = \\left\\langle P(t')P(0) \\right\\rangle = \\frac{1}{N_t-t'}\\sum_{t=0}^{N_t} P(t+t')P(t)\n",
+    "\\end{equation}\n",
+    "(note the denominator $N_t-t'$ for unbiased autocovariance)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Running calculation as implemented in LBMeX (adopted from DSMCGran):\n",
+    "$$ACF(t') = \\sum_{t=0}^{N_t} P(t)P(t-t')$$\n",
+    "(note normalization is dropped for now)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`scipy.signal.correlate` computes:\n",
+    "\\begin{equation}\n",
+    "z(k) = (x*y)(k-N+1) = \\sum_{l=0}^{n_x-1}x_ly^*_{l-k+N-1} \\qquad N=\\max(n_x,n_y) \\quad k=0,1,\\dots,n_x+n_y-2\n",
+    "\\end{equation}\n",
+    "(note the shifted lag)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ncorr = 5\n",
+    "P = np.array(allPeq) + np.array(allPneq)\n",
+    "P -= np.mean(P,axis=0) # center data for comparison with statsmodels acf\n",
+    "p = P[:,0,0,0,1,2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.07 ms, sys: 12 µs, total: 2.08 ms\n",
+      "Wall time: 2.42 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "x = p\n",
+    "data = np.zeros((ncorr,*x.shape[1:]))\n",
+    "acf = np.zeros((ncorr,*x.shape[1:]))\n",
+    "for t in range(nsteps):\n",
+    "    acf, data = update_autocorrelation(acf, data, x[t])\n",
+    "ps = acf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 217 µs, sys: 5 µs, total: 222 µs\n",
+      "Wall time: 190 µs\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ac_numpy = np.correlate(p,p,mode='fft')[len(p)-1:][:ncorr]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 177 µs, sys: 4 µs, total: 181 µs\n",
+      "Wall time: 172 µs\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ac_scipy = scipy.signal.correlate(p,np.concatenate([[0]*(len(p)-1),p]),mode='valid')[:ncorr]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 890 µs, sys: 0 ns, total: 890 µs\n",
+      "Wall time: 923 µs\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ac_sm = stattools.acf(p)[:ncorr]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.89 ms, sys: 0 ns, total: 1.89 ms\n",
+      "Wall time: 2.17 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# rolling acf (note that the average acf of the windows is _not_ equal to the acf of the full series)\n",
+    "v = p\n",
+    "data = np.zeros((ncorr, *v.shape[1:]))\n",
+    "acf = np.zeros((ncorr, *v.shape[1:]))\n",
+    "for t in range(nsteps+ncorr):\n",
+    "    data = np.roll(data,-1,axis=0)\n",
+    "    data[-1] = v[t] if t<nsteps else 0\n",
+    "    for idx in it.product(*map(range,v.shape[1:])):\n",
+    "        s = data if idx==() else data[:,idx]\n",
+    "        acf += scipy.signal.correlate(s,s)[len(s)-1:]\n",
+    "ac = acf/np.arange(ncorr,0,-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert(np.allclose(ps,ac))\n",
+    "assert(np.allclose(ps,ac_numpy))\n",
+    "assert(np.allclose(ps,ac_scipy))\n",
+    "assert(np.allclose(ps/ps[0],ac_sm)) # normalize zero lag correlation for comparison with statsmodels acf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAD4CAYAAADvsV2wAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAA7lUlEQVR4nO3deVxWZf7/8dcF3KyKGy647yIgIAKu5N5oueWSmtlQmdWkmTVZTU22jH2nqdwmG9NSs3Fc2rTFrKwsdwV3xAUVN1wQZedmu6/fHxA/NgXlhgPcn+fj4UPOOdc51/s+3X28OPe5r6O01gghhKj57IwOIIQQonJIwRdCCBshBV8IIWyEFHwhhLARUvCFEMJGOBgd4FY8PDx069atjY4hhBDVRkRExDWtdcOStlXpgt+6dWvCw8ONjiGEENWGUurszbbJJR0hhLARUvCFEMJGSMEXQggbUaWv4QtR3WVlZXHhwgXMZrPRUUQN4+zsTPPmzTGZTGXeRwq+EBXowoUL1K5dm9atW6OUMjqOqCG01sTHx3PhwgXatGlT5v2scklHKbVMKXVVKXXkJtuVUmqhUipaKXVIKRVojX6FqOrMZjMNGjSQYi+sSilFgwYNbvs3R2uN8FcA7wMrb7J9KNAh70934D95f1eI9QvmcePoNep5ezBqxsyK6kaIMpFiLyrCnbyvrDLC11r/Dly/RZORwEqdaxdQVynlaY2+i/pq7jtcOtKZNPpx6Uhn1i+YVxHdCCFEtVNZd+k0A84XWL6Qt64YpdRUpVS4Uio8Li7utjtKOJaAxc4BlD0WZc+No9fuLLEQolRTpkzh6NGjVj/ua6+9xrvvvgvAq6++yubNm8t9zAMHDrBx48abbt+/fz9TpkwptG7kyJH07NmzWDalFNHR0fnr5s2bh1Iq/4uirVu3pkuXLvj5+dG3b1/Onr3pd6EAmDt3Lo8++mj+8qpVq7j33nsBeP/991m+fHnZXmQpKqvgl/S7R4lPXtFaL9FaB2mtgxo2LPHbwbdUz8cDpS15nVqo5+1x28cQoibSWmOxWKx6zI8++ghvb2+rHrOoN954g0GDBhVbn5OTc1vHKa3gv/XWW0yfPj1/OSEhgX379pGQkMCZM2cKte3SpQtr1qzJX/7888+LnYdff/2VQ4cO0a9fP/7xj3/cMtvTTz9NREQE27dvJyEhgVdeeYV///vfADzyyCMsXLiwzK/zViqr4F8AWhRYbg7EVkRHo2bMpHH7/dhnp2HKvMawv0yriG6EqDARZ2+w6NdoIs7eKPexYmJi6Ny5M3/5y18IDAzk/Pnz1KpVK3/7559/TlhYGABhYWE8/fTT9OrVi7Zt2/L5558DsGXLFvr168fYsWPx8vJi0qRJ/PGkvH79+uWPamvVqsXLL7+Mv78/PXr04MqVKwCcOnWKHj16EBwczKuvvlqo/4LmzJlDp06dGDRoEMePH89fHxYWlp+ldevWvPHGG/Tp04fPPvuMH3/8kZ49exIYGMi4ceNISUkBYO/evfTq1Qt/f39CQkJITEzk1VdfZe3atQQEBLB27dpCfScnJ3Po0CH8/f3z133xxRcMHz6cCRMmFCruAKNGjWLDhg0AnD59mjp16nCzAWrPnj25ePEiAHFxcYwZM4bg4GCCg4PZvn07AA4ODnzwwQc89dRTzJo1i0ceeYS2bdsC4OrqSuvWrdmzZ0+Jx78dlXVb5tfANKXUGnI/rE3UWl+qqM7GzHqBT2b8jZSMQXw+5y0mvDa7oroSosxe/yaSo7FJt2yTbM7i2OVkLBrsFHg1qU1t55vfZ+3d1J3Zw31ueczjx4+zfPlyPvjgg1IzXrp0iW3btnHs2DFGjBjB2LFjgdzLHZGRkTRt2pTevXuzfft2+vTpU2jf1NRUevTowZw5c5g1axZLly7llVdeYcaMGcyYMYOJEyeyePHiEvuNiIhgzZo17N+/n+zsbAIDA+nWrVuJbZ2dndm2bRvXrl1j9OjRbN68GTc3N95++23mzp3Liy++yPjx41m7di3BwcEkJSXh6urKG2+8QXh4OO+//36xY4aHh+Pr61to3erVq5k9ezaNGzdm7NixvPTSS/nb3N3dadGiBUeOHGHDhg2MHz/+ppddNm3axKhRowCYMWMGM2fOpE+fPpw7d44//elPREVFAdCrVy86d+7M5s2b89f9ISgoiK1btxISElJiH2VlrdsyVwM7gU5KqQtKqUeVUk8opZ7Ia7IROA1EA0uBv1ij31sZ/fosHDPiSDnTDMtt/uonhFGSzNlY8i52WnTucnm1atWKHj16lKntqFGjsLOzw9vbO3+EDhASEkLz5s2xs7MjICCAmJiYYvs6OjoybNgwALp165bfZufOnYwbNw6ABx54oMR+t27dyn333Yerqyvu7u6MGDHiphnHjx8PwK5duzh69Ci9e/cmICCATz75hLNnz3L8+HE8PT0JDg4Gcouzg8Otx7aXLl0qNEK/cuUK0dHR9OnTh44dO+Lg4MCRI4XvOv9j5L9+/Xruu+++Ysfs378/jRo1YvPmzfmve/PmzUybNo2AgABGjBhBUlISycnJAKSkpBAeHk5WVhZFP79s1KgRsbHlvyhilRG+1npiKds18JQ1+iqr2nXrYtd2D5+77oHvzjFlxBuV2b0QxZQ2EofcyzmTPtpFVrYFk4MdCyZ0pVureuXq183NrdBywdv5it7H7eTklP/zH5dtiq63t7cnO7v4P0Qmkyn/2Ddrcytlvc3wj9ejtWbw4MGsXr260PZDhw7d9i2LLi4uhc7F2rVruXHjRv6XmpKSklizZk2ha/HDhw/n+eefJygoCHd392LH/PXXX3FzcyMsLIxXX32VuXPnYrFY2LlzJy4uLsXaz549mwcffJDGjRszc+ZMPvvss/xtZrO5xH1uV42eS2fSrDfRdW6w4cpXZGZmGB1HiFJ1a1WPVVN68OzdnVg1pUe5i31JGjduTFRUFBaLha+++srqxy+qR48efPHFFwDFroX/4a677uKrr74iPT2d5ORkvvnmmzIdd/v27fl3y6SlpXHixAm8vLyIjY1l7969QO71+ezsbGrXrp0/mi6qc+fOhe66Wb16NZs2bSImJoaYmJj8S04Fubi48Pbbb/Pyyy/fNKOLiwvz589n5cqVXL9+nbvvvrvQJaUDBw4AcPjwYb777jteeOEFpk6dytmzZ/npp5/y2504caLYJac7UaMLvrOTKyMZzLBtT7Bu9q0/JReiqujWqh5P9W9fIcUe4J///CfDhg1jwIABeHpWyNdhCpk/fz5z584lJCSES5cuUadOnWJtAgMDGT9+PAEBAYwZM4bQ0NBSj9uwYUNWrFjBxIkT8fPzo0ePHhw7dgxHR0fWrl3L9OnT8ff3Z/DgwZjNZvr378/Ro0dL/NDWy8uLxMREkpOTiYmJ4dy5c4Uug7Vp0wZ3d3d2795daL8JEyYQGHjriQM8PT2ZOHEiixYtYuHChYSHh+Pn54e3tzeLFy9Ga82TTz7JvHnzcHZ2xs7Ojg8++IAZM2aQmZkJwPbt20u8U+l2qYK/tlU1QUFBurwPQElPTWXVU+tRwOT/jMHRxdk64YQog6ioKDp37mx0DEOlpaXh4uKCUoo1a9awevXq/DtcqpJ58+ZRu3btYvfiG23//v3MnTuXTz/9tNi2kt5fSqkIrXVQSceq0SN8ABc3N1o2u4zZ2ZMtr//b6DhC2JyIiAgCAgLw8/Pjgw8+4L333jM6UomefPLJQp9VVBXXrl3jzTfftMqxbGK2zAGvTufS1LVcMDcnNSkRN/fiv1IKISpGaGgoBw8eNDpGqZydnZk8ebLRMYoZPHiw1Y5V40f4AA5Ojri1iCHduTFfvP620XGEEMIQNlHwAUbNfpE6Oevo5vwtWXLHjhDCBtlMwXcwmfCd0A8f01n2f/Mfo+MIIUSls5mCD+Df/36+vD6YIxvsSYyXWTSFELbFpgq+srMjq1EA6a4+fPVa1bxTQIjqpKKmR64oBaddvpn169dXq9d0O2yq4AOMeeEFnNNPkZkaRPzli0bHEaLSVNfpkUtTdAqH253SoSgp+DWIg8mEe+drZDnW4+t/LDI6jhDFnd8DW9/L/bucqtP0yCtXrsTPzw9/f//82yPPnj3LwIED8fPzY+DAgZw7dy4/67PPPkv//v154YUXii2fOnWKIUOG0K1bN0JDQzl27Fix/pYuXUpwcDD+/v6MGTOGtLQ0duzYwddff83zzz9PQEAAp06dKtOxqgubuA+/qNHPz2LFIx+RaR/M1QvnaNS8pdGRhC34/kW4fPjWbTKS4MoR0BZQdtDYF5yKT8yVr0kXGPrPWx6yOkyPHBkZyZw5c9i+fTseHh5cv577xNRp06bx0EMP8ec//5lly5bx9NNPs379eiB3fpnNmzdjb29PWFhYoeWBAweyePFiOnTowO7du/nLX/7CL7/8UqjP0aNH89hjjwHwyiuv8PHHHzN9+nRGjBjBsGHD8l97WY5VXdjcCB9yZ/Kr1zWJc7W+5sPNL5W+gxCVxZyYW+wh929zYrkPWR2mR/7ll18YO3YsHh65T6irX79+/r5/7DN58mS2bduWv8+4ceOwt7cvtpySksKOHTsYN24cAQEBPP7441y6VPzxG0eOHCE0NJQuXbqwatUqIiMji7Up67GqC5sc4QOMfuZ5PlsSyAVLBk8mXMKjbsVPIiVsXCkjcSD3Ms4nIyAnE+wdYcxH0KJ8D72oDtMja63LNKVxwTZFX9cfyxaLhbp16+bPRHkzYWFhrF+/Hn9/f1asWMGWLVuKtSnrsaoLmxzh/2F8hycZsncA61+Za3QUIXK1CIE/fw0DXs79u5zFviRVcXrkgQMHsm7dOuLj4wHyL+n06tUrf59Vq1YVu4xUEnd3d9q0aZM/n7zWusSpHZKTk/H09CQrK4tVq1blry84jXJZj1Vd2HTBH9X/MZqkdiQnPZS40zFGxxEiV4sQCH2uQoo9VM3pkX18fHj55Zfp27cv/v7+PPvsswAsXLiQ5cuX4+fnx6effsqCBQvK1OeqVav4+OOP8ff3x8fHp8TZOd988026d+/O4MGD8fLyyl8/YcIE3nnnHbp27cqpU6fKdKzqosZPj1yaLUuWEbmvNS0sOxmx5OYPMhDiTsj0yNVneuTq6HanR7bZa/h/6Df1ES5PXsglJ39ijkbS2rv0x9AJIcouIiKCadOmobWmbt26LFu2zOhINsvmCz5Aq0Ee7Nvpyi/z1vDIUuvMOy2EyFVdpke2BTZ9Df8PPf/8AK6ZP9LceTeJ8VdK30EIIaohqxR8pdQQpdRxpVS0UurFErbXUUp9o5Q6qJSKVEo9bI1+ranfX8cwqP4ejn4xx+goQghRIcpd8JVS9sAiYCjgDUxUShWdXOMp4KjW2h/oB7ynlHIsb9/W1MY7mF/tB3JyhytRe7YbHUcIIazOGiP8ECBaa31aa50JrAFGFmmjgdoq91sTtYDrQPlmOKoAquMokp0GsXPxj0ZHEUIIq7NGwW8GnC+wfCFvXUHvA52BWOAwMENrXeK0fUqpqUqpcKVUeFxcnBXild2ACZNxNkeQYd+TQ9t/rdS+hahIc+bMwcfHBz8/PwICAti9e3eJ7cLDw3n66acrOZ2oLNa4S6ek70MXvbn/T8ABYADQDvhJKbVVa51UbEetlwBLIPc+fCvkuy0dR7bm0A/2hH/8O369+1d290JY3c6dO/n222/Zt28fTk5OXLt2jczMzBLbBgUFERRU4i3cogawxgj/AtCiwHJzckfyBT0MfKlzRQNnAC+qoNDR43E2h2N26MG+X+TSjqh8B64e4KPDH3Hg6gGrHO/SpUt4eHjkz4fj4eFB06ZN2bt3L7169cLf35+QkBCSk5PZsmVL/gRor732GpMnT2bAgAF06NCBpUuXArmTmBX84tSkSZP4+uuvrZJVVCxrjPD3Ah2UUm2Ai8AEoOiUeOeAgcBWpVRjoBNw2gp9VwjvsV4c+OIAX+7ZRuCAu42OI2qQhzfd+ga1lMwUohOisWgLjvaOtHZvzSTvSYxqP4ob5hs8u+XZQu2XD1leap933303b7zxBh07dmTQoEGMHz+enj17Mn78eNauXUtwcDBJSUm4uLgU2/fQoUPs2rWL1NRUunbtyr333suUKVOYN28eI0eOJDExkR07dvDJJ5/c3okQhij3CF9rnQ1MA34AooB1WutIpdQTSqkn8pq9CfRSSh0GfgZe0FpX2YfK9hx+H0d6fc/GJmc4dGKH0XGEDUnOSiZH52DBQpYli+Ss5HIfs1atWkRERLBkyRIaNmzI+PHj+fDDD/H09CQ4OBjInSTMwaH4+G/kyJG4uLjg4eFB//792bNnD3379iU6OpqrV6+yevVqxowZU+K+ouqxyn8lrfVGYGORdYsL/BwLVKuh8uP93iJh3atsXfA//Bb1MjqOqCFKG5EfuHqAx358jCxLFiY7E/8M/ScBjQIAqOdcr0wj+pLY29vTr18/+vXrR5cuXVi0aNFtT0dccHny5MmsWrWKNWvWyFQJ1Yh80/Ym/Dr2YsCpu1BZI4n47luj4wgbEdAogKV3L2Va12ksvXtpfrEvj+PHj3Py5Mn85QMHDtC5c2diY2PZu3cvkDtVcEnz12/YsAGz2Ux8fDxbtmzJ/40gLCyM+fPnA7kzXYrqQX4Pu4WgsD7sWJXFmbVRdLt3mNFxhI0IaBRglUL/h5SUFKZPn05CQgIODg60b9+eJUuW8PDDDzN9+nTS09NxcXFh8+bNxfYNCQnh3nvv5dy5c/z973+nadOmQO6c+p07d2bUqFFWyykqnhT8W/DvO4BTy/+Pyy5BHPl2E77DhhgdSYjb1q1bN3bsKP5ZlIeHB7t27Sq07o/LPn/o2LEjS5YsKbZvWloaJ0+eZOLEiVbPKyqOXNIpRdC0oShLDns+O2R0FCGqhM2bN+Pl5cX06dNLfJiJqLpkhF+KlkEBOC1+GZPK4HTkXtr6BBsdSYhK8dprr5W4ftCgQZw7d65ywwirkBF+GYx66y+MabWSG5tkJk0hRPUlBb8M6jdqxv6m47l2KpOfV8ktaEKI6kkKfhl59nqEM5lPEfNDotFRhBDijkjBL6O2XbriqHZhdvXn+48Wl76DEEJUMVLwb0O/Z8Zhn51G7O8ZRkcRosyUUjz33HP5y+++++5NP5AVNZsU/NvQ1scPR7udmF278M0H/zY6jhBl4uTkxJdffsm1a1V2+ipRSaTg36bBzz+Eo/kih6J3Gh1F1FBp+/dz7cMlpO3fb5XjOTg4MHXqVObNm1dsW1hYGJ9//nn+cq1atQDYsmULffv25f7776djx468+OKLrFq1ipCQELp06cKpU6fy93/iiScIDQ2lY8eOfPtt7jQkoaGhHDhwIP+4vXv35tAh+S6L0eQ+/NvUokMnLvT9O1/aReH721JG9n3M6EiiGjk7+aFi62oPHUL9Bx7Akp5OzAOTyDh2DLQGpXDy8qL+5MnUHX0f2TducPHpGYX2bfXpyjL1+9RTT+Hn58esWbPKnPXgwYNERUVRv3592rZty5QpU9izZw8LFizg3//+d/5cOjExMfz222+cOnWK/v37Ex0dzZQpU1ixYgXz58/nxIkTZGRk4OfnV+a+RcWQEf4dmH7fAjzMcGSDPAZRWJclKSm32ANonbtsBe7u7jz00EMsXLiwzPsEBwfj6emJk5MT7dq14+67cye87dKlCzExMfnt7r//fuzs7OjQoQNt27bl2LFjjBs3jm+//ZasrCyWLVtGWFiYVV6HKB8Z4d8Bj7qePHj4HszZf+KLd//FmL+WfdQkbNutRuR2Li40ffcdzj38CDorC2Uy0fTdd3Dt2hUAh3r1yjyiL8kzzzxDYGAgDz/8/x/C4uDggMWS+3hprXWhRx/+8YQsADs7u/xlOzu7QjNrljSFsqurK4MHD2bDhg2sW7eO8PDwO84trEdG+HdoxEvTMGUmkn6wLjklTCsrxJ1w7dqVlsuX0fDpp2m5fFl+sbeG+vXrc//99/Pxxx/nr2vdujURERFA7lTIWVlZt33czz77DIvFwqlTpzh9+jSdOnUCYMqUKTz99NMEBwdTv35967wIUS5S8O9Qw2YtaOYaRaJbe3YskG/fCutx7doVj8enWrXY/+G5554rdLfOY489xm+//UZISAi7d+/Gzc3tto/ZqVMn+vbty9ChQ1m8eDHOzs5A7iyd7u7uhX6jEMZS+o/rhVVQUFCQrsq/CibFXWPtC79hn3Odhz4Kw8FkMjqSqGKioqLo3Lmz0TEqTFhYGMOGDWPs2LHFtsXGxtKvXz+OHTuGnZ2MLStCSe8vpVSE1jqopPbyX6Ec3Bt6YHILx4IjO9avMDqOEFXGypUr6d69O3PmzJFiX4XICL+cUpISufFuEOmOdenwt90oeXOLAmr6CF8YS0b4layWex0u+T9FnbRLfLv4PaPjCCHETVml4CulhiiljiulopVSL96kTT+l1AGlVKRS6jdr9FtVdB3+JN9cfJMruxuRfQd3OQghRGUod8FXStkDi4ChgDcwUSnlXaRNXeADYITW2gcYV95+qxKToxOOHtFkuLRg7Wv/MDqOEEKUyBoj/BAgWmt9WmudCawBRhZp8wDwpdb6HIDW+qoV+q1SxsyehaP5CukX25NpNhsdRwghirFGwW8GnC+wfCFvXUEdgXpKqS1KqQilVPEJRao5N/c6ODeKJMO5Getmy6MQRdU2f/580tLSrNbOWl577TXefffdcre5U3FxcXTv3p2uXbuydevWCunDSNYo+KqEdUVv/XEAugH3An8C/q6U6ljiwZSaqpQKV0qFx8XFWSFe5Rk7+yWczLEkXdVkZsqc+aLqqqoF32g///wzXl5e7N+/n9DQUKPjWJ01Cv4FoEWB5eZAbAltNmmtU7XW14DfAf+SDqa1XqK1DtJaBzVs2NAK8SqPi5sblkGH+U+/DXy4ocTProUo1eXTiURsiuHyaes8TjM1NZV7770Xf39/fH19ef3114mNjaV///70798fgCeffJKgoCB8fHyYPXs2AAsXLizULicnh7CwMHx9fenSpUv+dMv9+vVj5syZ3HXXXXTu3Jm9e/cyevRoOnTowCuvvJKfY+7cufj6+uLr65s/0ybAnDlz6NSpE4MGDeL48eP560+dOsWQIUPo1q0boaGhHDt2rNhrW7hwId7e3vj5+TFhwoRi21NSUhg4cCCBgYF06dKFDRs25G9buXIlfn5++Pv7M3nyZA4cOMCsWbPYuHEjAQEBpKenl+/EV0Va63L9IXf0fhpoAzgCBwGfIm06Az/ntXUFjgC+pR27W7duurrJysrUw5b46rC3QnVKYoLRcYTBjh49Wmj5y3cjiv059Ot5rbXWmRnZes2bu/X7T/ys33/8Z/3+Ez/rNW/u1ke3x2qttU5Lzii2b1l8/vnnesqUKfnLCQkJulWrVjouLi5/XXx8vNZa6+zsbN23b1998OBBrbUu1C48PFwPGjQof58bN25orbXu27evnjVrltZa6/nz52tPT08dGxurzWazbtasmb527ZoODw/Xvr6+OiUlRScnJ2tvb2+9b9++/PWpqak6MTFRt2vXTr/zzjtaa60HDBigT5w4obXWeteuXbp///5aa61nz56d38bT01ObzeZCeQrKysrSiYmJWmut4+LidLt27bTFYtFHjhzRHTt2zH9tf7z+5cuX66eeeqpM57UqKPr+0lprIFzfpKaWe4Svtc4GpgE/AFHAOq11pFLqCaXUE3ltooBNwCFgD/CR1vpIefuuihwcTNyfPIqgmL/zxex/GR1HVDMZ6dn//4Kozlsupy5durB582ZeeOEFtm7dSp06dYq1WbduHYGBgXTt2pXIyEiOHj1arE3btm05ffo006dPZ9OmTbi7u+dvGzFiRH5fPj4++dMqt23blvPnz7Nt2zbuu+8+3NzcqFWrFqNHj2br1q1s3bqV++67D1dXV9zd3fOPk5KSwo4dOxg3bhwBAQE8/vjjXLp0qVgmPz8/Jk2axH//+18cHIpP/qu15m9/+xt+fn4MGjSIixcvcuXKFX755RfGjh2Lh4cHgM1M7maV6ZG11huBjUXWLS6y/A7wjjX6q+omTn+VlVNWkZXpjzkpCecC/2MI23bfc4E33WZytOfuR33YMG8/OTkW7O3tuPtRH5q0zS3QLrUcb7n/zXTs2JGIiAg2btzISy+9lD+v/R/OnDnDu+++y969e6lXrx5hYWGYS7jTrF69ehw8eJAffviBRYsWsW7dOpYty504sODUyUWnVc7Ozv7jN/0SFZ1eGcBisVC3bt1CT80qyXfffcfvv//O119/zZtvvklkZGShwr9q1Sri4uKIiIjAZDLRunVrzGYzWusS+63p5Ju2FcDBZKJtxxTMTh5smf2B0XFENdKkbR1GzuxK9xFtGTmza36xL4/Y2FhcXV158MEH+etf/8q+ffuoXbs2ycnJACQlJeHm5kadOnW4cuUK33//ff6+Bdtdu3YNi8XCmDFjePPNN9m3b1+ZM9x1112sX7+etLQ0UlNT+eqrrwgNDeWuu+7iq6++Ij09neTkZL755hsg94Etbdq04bPPPgNyR+oHDx4sdEyLxcL58+fp378///rXv0hISCAlJaVQm8TERBo1aoTJZOLXX3/l7NmzAAwcOJB169YRHx8PwPXr12/nlFZb8gCUChL6whOce+QTzme040bcZeo1bGJ0JFFNNGlbxyqF/g+HDx/m+eefx87ODpPJxH/+8x927tzJ0KFD8fT05Ndff6Vr1674+PjQtm1bevfunb/v1KlT89vNnz+fhx9+OP+BKf/3f/9X5gyBgYGEhYUREhIC5M6V3zVv+ufx48cTEBBAq1atCt0Zs2rVKp588kn+8Y9/kJWVxYQJE/D3///3euTk5PDggw+SmJiI1pqZM2dSt25dwsPDWbx4MR999BGTJk1i+PDhBAUFERAQgJeXFwA+Pj68/PLL9O3bF3t7e7p27cqKFSvu+BxXFzJ5WgVaN+cfXDsbQv2mPzPhtbeNjiMMIJOniYokk6dVIaNnvYCvx9sMYB3m9FSj4wghbJwU/ArkYDJR/95naMR1tix/y+g4QggbJwW/gvn2Hs7ys09xNjyYq+fPGh1HGKAqXzYV1dedvK+k4FeCul3qk+3ozndvfWh0FFHJnJ2diY+Pl6IvrEprTXx8fP7zg8tK7tKpBPc9+1c+fmgRmabuxJ45SdM2HYyOJCpJ8+bNuXDhAtVtXihR9Tk7O9O8efPb2kcKfiXxCM7iQmRtNr29gkcWy2yatsJkMtGmTRujYwgByCWdSjNy+jM4px0hJ8OX2MsxRscRQtggKfiVyHO4MytC3mPR988aHUUIYYOk4Feie8ZNpb2dYkv2cWLOHC99ByGEsCIp+JXswQ7PELb9b/wy579GRxFC2Bgp+JVs8IBJ2FuukEkPLh0pPgWtEEJUFCn4Bug2vD059k7snrve6ChCCBsiBd8A/uNG0DDtEJfsu3Jk5zaj4wghbIQUfIM0GdEEi52JPcs2lt5YCCGsQAq+Qe4a9wAetf/L6MYfc+3yOaPjCCFsgBR8A/V+4q/Uss/k+GdvGB1FCGEDpOAbqHl7X9YljyFy/xAifv6+9B2EEKIcpOAbrM3AYWQ71OHgpxFGRxFC1HBS8A3W895ROGXuwewYwq7vvzY6jhCiBrNKwVdKDVFKHVdKRSulXrxFu2ClVI5Saqw1+q0p/CZ1BTRH1x42OooQogYrd8FXStkDi4ChgDcwUSnlfZN2bwM/lLfPmiZ48D04ZeWO8ndu2mB0HCFEDWWNEX4IEK21Pq21zgTWACNLaDcd+AK4aoU+a5xuD/ckssEiPjn3rtFRhBA1lDUKfjPgfIHlC3nr8imlmgH3AYtLO5hSaqpSKlwpFW5LTwkKuGsQju3S2Ol4g50H5ZcgIYT1WaPgqxLWFX2A53zgBa11TmkH01ov0VoHaa2DGjZsaIV41ceTg98lbNswjs6TO3aEENZnjYJ/AWhRYLk5EFukTRCwRikVA4wFPlBKjbJC3zVKx1Z+1NFOmJ1C2P+ZXMsXQliXNQr+XqCDUqqNUsoRmAAUur9Qa91Ga91aa90a+Bz4i9Z6vRX6rnEGTh+NfU4mJ78+bXQUIUQNU+6Cr7XOBqaRe/dNFLBOax2plHpCKfVEeY9va1oF+OOpDxDn5s/vn640Oo4QogZxsMZBtNYbgY1F1pX4Aa3WOswafdZk3WaO5NL8GE7+FM9dk41OI4SoKeSbtlVQc18f3Nx/IqjhCqIPbjc6jhCihpCCX0WNfPXvtK4dR8oPbxodRQhRQ0jBr6Lc6zZgh/sE9h8ZzDeLFhgdRwhRA0jBr8J8hz9OpqkDV3fbGx1FCFEDSMGvwlp06ISjaTdmV2/Wz59rdBwhRDUnBb+KG/rSIzhkJRG/z8XoKEKIak4KfhXXpFU7HJ32YHbtxBf/+pfRcYQQ1ZgU/Gpg2CtPkpn9HRvtv8KSU+p0REIIUSIp+NVAw6YtMPePZ49HCut+ljt2hBB3Rgp+NfHUqHncHdWOpP+lkJ2VZXQcIUQ1JAW/mnB3q0eXtM5kOfdh09syyhdC3D4p+NXIfbOfwznjGtdPNCAnO9voOEKIakYKfjVSp4EHzeqfIdm1FZvnLDQ6jhCimpGCX830m/0kThlxnD/dgKzMTKPjCCGqESn41YyzuzvOTQ5Rx3ELB3741Og4QohqRAp+NTTxzdfp3mI3HvsXyH35Qogyk4JfDdk7OBDbZToR57uy5rXZRscRQlQTUvCrqYA//ZmErMGknvcmPTXV6DhCiGpACn415ezqikvTE2Q6N+Gz2W8ZHUcIUQ1Iwa/Gxr36N5zSL5AR34XUpESj4wghqjgp+NWYo7Mzri1PkenUiM9nv210HCFEFWeVgq+UGqKUOq6UilZKvVjC9klKqUN5f3Yopfyt0a+A+199BVP6Lo44HiXNLNfyhRA3V+6Cr5SyBxYBQwFvYKJSyrtIszNAX621H/AmsKS8/YpcDiYTTvdrNnmfYtFXzxodRwhRhVljhB8CRGutT2utM4E1wMiCDbTWO7TWN/IWdwHNrdCvyDN5yIt0i3fD/lcXbsRdNjqOEKKKskbBbwacL7B8IW/dzTwKfH+zjUqpqUqpcKVUeFxcnBXi1Xx29vbckz4cJ7sRfPvGv42OI4SooqxR8FUJ63SJDZXqT27Bf+FmB9NaL9FaB2mtgxo2bGiFeLZh9KxZ1Eo7RUZqN5Kuyj+UQojirFHwLwAtCiw3B2KLNlJK+QEfASO11vFW6FcU4GAy0a6rIsOxLr+/vtToOEKIKsgaBX8v0EEp1UYp5QhMAL4u2EAp1RL4EpistT5hhT5FCfrMnEKttBNcTPfm6vmzRscRQlQx5S74WutsYBrwAxAFrNNaRyqlnlBKPZHX7FWgAfCBUuqAUiq8vP2Kkrl3TcExO4aILxcZHUUIUcUorUu83F4lBAUF6fBw+bfhdh365wBamE9ievYQtdzrGR1HCFGJlFIRWuugkrbJN21rIKdBrxCbUpf1/3jD6ChCiCpECn4N1CloALuuTiHl+gDOnThqdBwhRBUhBb+GatLHRI6DG5vf+Z/RUYQQVYQU/Brq3ql/wTntEJm6B9GH9xsdRwhRBUjBr8Ga93cjx8GV3xd8ZXQUIUQVIAW/BvvTw4/hnL6XJDI4GytffxDC1knBr+HaT+/Esj7f8f73zxgdRQhhMCn4NVzfoFF0z3Qn5bQDR3ZuMzqOEMJAUvBtwIOeT+N77Wl2L/3Z6ChCCANJwbcBfYdPwN28j0z77sTskm8uC2GrpODbiOCJ3dB29uxbvNnoKEIIg0jBtxFeQwZS37yfy45difj5ps+fEWWwfsE8lj/+MusXzDM6ihC3xcHoAKLytLq/I0lfpHL8u010GzjU6DjVRnpqKkd3/c65Q5Fcj7xBhl1ftFKYj+SwfsE8Rs2YaXREIcpECr4N6XnvKHJOTCYk4TsunX0Oz1adjI5UJaQmJnJxzwHiIk9y/vx5zBmpeLe/iFvaRXYfG43Z2Rtt5wQE5v4fozUohUXBtX3ZnDt5jJYdvIx+GUKUSqZHtjFXLpzCbXEPNmYN4/63lxsdp1LciLvMka2/c/lYNGlXU8hOt7C721YSSGXAjnHkOHUH9f+vbpoyExjV8jmuOzRm59neWCy1sHfLxMXDlYxkM6kJoViUPQoL2s6EfXYaTSyHCJh6N617lDgrrRCV5lbTI8sI38Y0bt6OZZenkG4/gG0bPqPPyHFGRyq3qxfOEbvnEInHz3H1chzJKTl07nSEepmx7I7uS4rTYFAegAcASmdzRn9LXeVARu2z1E7PoEltV2o3rYdrJ0/a9OxJ/YZnaASUNG5fv2AeN45eo563B/YmB1J2ZnPRNYTYZfE4Lf4//B70JXjQ8Mo8BUKUiYzwbdDBrb+wY2UmjpkHePSTF42OU6rzJ49zbOc2rp26QEZ8BpY0Rw52/o3zdeLpvr8PtfTYQu2VJYdu9V6hVh0nDsZ1xJziiX3tHNyauNPMxwvf3v2oXbeuVTNGbdxM+LrdpNt1ZpznU8TUCcDs/RA9h020aj9ClOZWI3wp+Dbq40dex2zqje/gq/Qd+4BhObKzsog5doS4fVGkn4kjMS6J6+kWGjU+QmfXUxy62IFLPF5oH2XJ4ljj+VxrfgWf8+3wvNoRj7puNGzVlPq+7WgZFIiLm5shryc25gRnf/6Q9mfXsf7c29jpVFxaXmDsyy/h6OxsSCZhW6Tgi2KO7NzG1mXJOGYe4dFPnq+wfrKzsji5fw/R4ftIOn+VzIQcLGYXzjfaT3j7k7SMaY1PfOG7XOxyMmjouIIOLeI5a27GtcvNcayjqN28AW0CA/Dq1rPKF88bcZdZ//oCslO7kunkgaP5MqY6hxn+0jQaNGlmdDxRg0nBFyVa9uhscnI60nGKM337jLmjY2RmZhC1eztxh46jL6aSfj2DaxkaZ7dT9G60l4Rke7YlF75f3T47nUSnL4n0P0Sz5IZ0jA6gbn03mrdrS9NufjT27oiDyWSNl2i41KREvprzDubL7clwacll548hIJOpQ96mRZO2RscTNZAUfFGik8cO8OdtD+KVU4tlj+8qsU1Odjb7fv2R84cjSYlNIDtJQaYriS7n2dRtK4kWeyZHvFfoLheHrBSc+QU/r5OkOHsSHdUIpwYm6rXypFPPXrT18ausl1hlZGdl8dV777LB/QsOumUwcVcoTTIaE/JAKL6DBhgdT9QgFV7wlVJDgAWAPfCR1vqfRbarvO33AGlAmNZ6X2nHlYJf8V5cNoLEEw4ExfbG1ZSKq50DNzLt0fbx/KnVehparrHs/MdkO9bJ38chMwkLewnv/jP17Ovhc8QP93rutPPypUX3rjRo3dLAV1T1bd79GWc+PEyWQygoaJh2iOZ3N6XnZPmAV5RfhRZ8pZQ9cAIYDFwA9gITtdZHC7S5B5hObsHvDizQWncv7dhS8CvemrffIP50b1Aqd4W2YMpKwiHnGH5+4WTVbk50tCuO7rVo1LENPr3volGzFsaGriGiftnCsU93csXenxwHZ1wzfyD44V749B6OspNZT8Sdqej78EOAaK316bzO1gAjgaMF2owEVurcf112KaXqKqU8tdaXrNC/KIf00xmABhToHFwtv/Hwsn8UatPTkGQ1X+cB/eg8oB9nI4/wy8LVeNY6gO/Pi/nt20DO0ZvRLz+Pm3ud0g8kRBlZo+A3A84XWL5A7ii+tDbNgGIFXyk1FZgK0LKlXBqoaPW8PTAfycai7LHTOdTzbWB0JJvTyseXhz+cgzk9lT0bl3D22/MkOw3gfzN+wMHtAEOff5QmrdoZHVPUANb4vVGVsK7odaKytMldqfUSrXWQ1jqoYcOG5Q4nbm3UjJl4+kbhqrbg6RslE4EZyNnFjZAxM5nwn7eo1/A37CyJpGUPYv0bkXw89WVOn480OqKo5qwxwr8AFLyo2xyIvYM2wiBS5KsWR2dnHnjzdQDWz3uP+P32mC2u3L95PD2zGzKh+XR6Dx1tcEpRHVmj4O8FOiil2gAXgQlA0a9ufg1My7u+3x1IlOv3QpRu1MznANga/i0h+34k6ZIjB8LdObV6Ll59mxDyqHHfkhbVj7Vuy7wHmE/ubZnLtNZzlFJPAGitF+fdlvk+MITc2zIf1lqXevuN3KUjRGGHdvxK+Me/kqVCyHZwxT3tJKZ2lxnz0kuYHB2NjieqAPnilRA1THzMOXb+679cMncix86Zno1nkxkchv/QKTg6Ve1pJ0TFkumRhahhGrRuybAP/kZyQgI/fjgX94wsWu57mU++1Ci3Swyc+SAtO3obHVNUMTLCF6IG0BYL275YxolvsjC7dsI+Ox1HvYfAyaEE9BtkdDxRieSSjhA25LsPF3F5Rzpm5wCUtnCjwUfcNe5BQgNHGB1NVAIp+ELYoO0bviBqwwE+7rGBFCfNAwf86NQigBHTn6kxs5GK4qTgC2HDzlw8xtJNL9Lm9/vIdGmBe9oZmrZJIvTFJ3F0kQ94axop+EIIrp4/y+//WkFSshfpzg1xNF/BtelBxrzyCs6utYyOJ6zkVgVfpuQTwkY0atGKsf+ezYOLRtCy/h6UNtMw8SCp//Lmx4UziT4og6uaTm7LFMLGOLq5MPytF8nOyiJqpwcXdi7kyj5HTh2O4/fsN+h8fwA9h8oHvDWRXNIRQvDTyo859/M1MpwC0QqczQdoGlqboVOeMDqauE1ySUcIcUuDH3qURz95geBxWbhkbSfT0YeYbUk88GEg//vhXbKzsoyOKKxALukIIfIFD76H4MH3cDryEOt+XM1Fhww27P2BtP95UKfxWUa8+lecarkZHVPcIbmkI4S4qeTUBNa+8zo6JphM5yY4Z8TTwPU4Ic9PoGnr9kbHEyWQ2zKFEOWSZc5g2zsfcvGkC4mu7TBlXqdz99/xHjWLBo2bGx1PFCAFXwhhNRsWzCPx2AkebLQas8WBNZem0P4ef+4aPdHoaAIp+EKICnD+5EH2ffoeFy9PQit7nNMP0zBYMWL6M0ZHs2lS8IUQFebQ9i2EL/+FTELIcXDFOe0kjnddYmLYyzg4yJw9lU0KvhCiwl2IPsFPc1eQk9qeD/sspCHZDE8cSCOLJ0mnkqnn7SHPT64E8gAUIUSFa96+Iw9/8BZp5lTSvz3Cz9c2o47247LJHdCkR+awfv57jHrmOaOj2iz54pUQwqpcnd2YPnYunz8agSnnWO5KZYe2M3H5iBefTJvOwV/WYE5LMTaoDZIRvhCiQjiYTDQIdObSkSwsyh6FxiHzPA0cY/D/fSW7v/HiSPwDONS7gv99A+TJXJVAruELISrU+gXzuHH0Wv41/AxzGsd3fc+Rb34i5fpAspwaAOCUfg47x1N4jmzD3UMfwt5exqN3osI+tFVK1QfWAq2BGOB+rfWNIm1aACuBJoAFWKK1XlCW40vBF6Jmy87K4tfVKzm/4zQ6vTWZji34pNvfcDZlMDyqG01d23L344/RoFkzo6NWGxVZ8P8FXNda/1Mp9SJQT2v9QpE2noCn1nqfUqo2EAGM0lofLe34UvCFsC3HD+/l+6hPOZSwm57bw8h06YRdTiZ1zdHY17tGmxEhBA+6x+iYVVpFFvzjQD+t9aW8wr5Fa92plH02AO9rrX8q7fhS8IWwXYnx1/h96QqyjmWRQFvSnRvikhZJ3w7LiPPsT4J9JwZM/DOOzvKYxoIqsuAnaK3rFli+obWud4v2rYHfAV+tddJN2kwFpgK0bNmy29mzZ+84nxCiZsjJzua3dau4Hn0AH/vduCRd4buED3HISsEhJwqXFmb6TZksE7pRzoKvlNpM7vX3ol4GPilrwVdK1QJ+A+Zorb8sS3AZ4QshSnLueCS/Lf0fmXH1yDJ5kePgirJkkei2EoKcGNrtYQK8Qo2OaYhyffFKa33Te6WUUleUUp4FLulcvUk7E/AFsKqsxV4IIW6mZScfJr87B4DkhAR++PA/JB7PIKrJWfZnJ5L6AYQnxeBuH0PL4FYE/vl+HF3k0k95L+m8A8QX+NC2vtZ6VpE2CviE3A93n7md48sIXwhxO7TFws7DP3D4v9/jcNWHDOe2aGWPKSsZ++wofMc2wKfvWGq53/TKc7VXkdfwGwDrgJbAOWCc1vq6Uqop8JHW+h6lVB9gK3CY3NsyAf6mtd5Y2vGl4AshyuNK1AkOrvyaS7GQrWvxaNsXyNQO/O/CI2gXE15DQug5bJTRMa1KJk8TQti87KxMju/dTOKBrzm6uzsZLq0AcDLHYmd/kvrd6nDPlKdwdHQyOGn5SMEXQogifv9yNac2H8aS0oIM5/ak6Z9Y3/M7/NIa0OtCX/qEjae1l6/RMW+bFHwhhLiF05GH+Hn3p+zN3kHtU01om/gUypJD3fRoarlfp/7dHekzcpzRMctECr4QQpRRWkoyPyz9kJzDZlJy2pDq4glAe9e3qdOxHbpFKH6h9+DmXsfgpCWT+fCFEKKMXGvV5r6Zf81f3v3NeqJ+2E3jBma8L61hza4GHPyqFqasYzg2SaTn5LG09w0wLvBtkBG+EEKUUXLidb6bt4DUMy5kO3Qm21QbdA5O5oPEDtrPYP/J9PQbYmhGuaQjhBBWlp6ayg8ffcj1QwmkqFSWhv4IFs2MLU9hso+jXZemBD16P87u7pWaSwq+EEJUsH3HtvLzb8upvz2QDOcOaDsTDtlpmLKOUdsribunPkWdBo0rPIdcwxdCiAoW6BVKoFcoPA7xMec4sPwL4s5kkWjqiOu5Fbgt9OKHjJ7EJgbQqm9n7hozAQeTqVIzyghfCCEqUKbZzIl9W0iO3MTpvWkk2E0AwDEjDnuOU7ujiT898Tju9epbpT+5pCOEEFXE3h83EvnNNnISPclw7gjAFwEv0MremZ7JPamVWg9zbEb+IyFvlxR8IYSogi6fPcXPq1ewvf5vRNrHM2nri2Q5NQU0dpZsPH2jbrvoyzV8IYSogpq0asekF99kEpCdncUn2/5JFp6g7LAoe24cvWbV/uysejQhhBB3xMHBRIOAWthZssGSg53OoZ63h1X7kIIvhBBVxKgZM/H0jcJVbbmjyzmlkUs6QghRhVi7yBckI3whhLARUvCFEMJGSMEXQggbIQVfCCFshBR8IYSwEVLwhRDCRlTpqRWUUnHA2Tvc3QOw7tfUrENy3R7JdXsk1+2piblaaa0blrShShf88lBKhd9sPgkjSa7bI7luj+S6PbaWSy7pCCGEjZCCL4QQNqImF/wlRge4Ccl1eyTX7ZFct8emctXYa/hCCCEKq8kjfCGEEAVIwRdCCBtRrQu+UmqIUuq4UipaKfViCduVUmph3vZDSqnAKpKrn1IqUSl1IO/Pq5WUa5lS6qpS6shNtht1vkrLZdT5aqGU+lUpFaWUilRKzSihTaWfszLmqvRzppRyVkrtUUodzMv1egltjDhfZcllyHssr297pdR+pdS3JWyz7vnSWlfLP4A9cApoCzgCBwHvIm3uAb4HFNAD2F1FcvUDvjXgnN0FBAJHbrK90s9XGXMZdb48gcC8n2sDJ6rIe6wsuSr9nOWdg1p5P5uA3UCPKnC+ypLLkPdYXt/PAv8rqX9rn6/qPMIPAaK11qe11pnAGmBkkTYjgZU61y6grlLKswrkMoTW+nfg+i2aGHG+ypLLEFrrS1rrfXk/JwNRQLMizSr9nJUxV6XLOwcpeYumvD9F7wox4nyVJZchlFLNgXuBj27SxKrnqzoX/GbA+QLLFyj+pi9LGyNyAfTM+xXze6WUTwVnKisjzldZGXq+lFKtga7kjg4LMvSc3SIXGHDO8i5PHACuAj9pravE+SpDLjDmPTYfmAVYbrLdquerOhd8VcK6ov9ql6WNtZWlz33kznfhD/wbWF/BmcrKiPNVFoaeL6VULeAL4BmtdVLRzSXsUinnrJRchpwzrXWO1joAaA6EKKV8izQx5HyVIVelny+l1DDgqtY64lbNSlh3x+erOhf8C0CLAsvNgdg7aFPpubTWSX/8iqm13giYlFLWfTz9nTHifJXKyPOllDKRW1RXaa2/LKGJIeestFxGv8e01gnAFmBIkU2Gvsdulsug89UbGKGUiiH30u8ApdR/i7Sx6vmqzgV/L9BBKdVGKeUITAC+LtLma+ChvE+6ewCJWutLRudSSjVRSqm8n0PI/e8QX8G5ysKI81Uqo85XXp8fA1Fa67k3aVbp56wsuYw4Z0qphkqpunk/uwCDgGNFmhlxvkrNZcT50lq/pLVurrVuTW6d+EVr/WCRZlY9Xw53HtdYWutspdQ04Ady74xZprWOVEo9kbd9MbCR3E+5o4E04OEqkmss8KRSKhtIBybovI/kK5JSajW5dyN4KKUuALPJ/QDLsPNVxlyGnC9yR2CTgcN5138B/ga0LJDNiHNWllxGnDNP4BOllD25BXOd1vpbo/+fLGMuo95jxVTk+ZKpFYQQwkZU50s6QgghboMUfCGEsBFS8IUQwkZIwRdCCBshBV8IIWyEFHwhhLARUvCFEMJG/D9QOTLeZzYJsQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(ps/ps[0],'.-',label='running direct (AMReX)')\n",
+    "plt.plot(ac/ac[0],'.-',label='running correlate')\n",
+    "plt.plot(ac_scipy/ac_scipy[0],'.-.',label='Scipy')\n",
+    "plt.plot(ac_numpy/ac_numpy[0],'.--',label='Numpy')\n",
+    "plt.plot(ac_sm,'.--',label='statsmodels.acf')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ESPResSo",
+   "language": "python",
+   "name": "pypresso"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Hi @nkarthi95,

The issue with the autocorrelation is related to the use of the `correlate` function. 

First, you want to correlate in time only, not in space, so `correlate` needs to be called for each space point separately.

Second, remember the shifted lag in the numpy/scipy correlate function (cf. the documentation https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.correlate.html). You can slice the second half ``[len(data)-1:]`` of the returned array to get the needed lag values.

Finally, if you calculate the acf for a sliding window, the sum/average of the indivudal convolutions is not the same as the convolution of the full time series (see also https://stats.stackexchange.com/questions/111840/library-routine-for-rolling-window-lag-1-autocorrelation for a discussion of rolling window autocorrelation). Consider for example the zero lag correlation: $x(t)\cdot x(t)$ is included in the acf for as many times as it remains in the rolling queue, i.e., max lag times. Similarly $x(t)\cdot x(t+1)$ is included max lag minus one times. So one needs to divide the running acf by the correct factor for each lag.

I have compared the alternative calculations in the notebook. I separated computation from data processing and used small values for `nsteps` and `ncorr` for rapid prototyping and validation. The rolling `correlate` becomes slow because the convolution has to be calculated for each array dimension. I believe the rolling direct calculation is flexible enough for our purposes, as it works for arbitrary array shapes.